### PR TITLE
Update explainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ The developer can compute the DCLS score by summing the LS scores:
 
 ```javascript
 addEventListener("load", () => {
+  let DCLS = 0;
   new PerformanceObserver((list) => {
       list.getEntries().forEach((entry) => { DCLS += entry.value; });
   }).observe({type: "layout-shift", buffered: true});

--- a/README.md
+++ b/README.md
@@ -108,17 +108,15 @@ interface LayoutShift : PerformanceEntry {
 
 The entry's `value` attribute is the LS score.  Its
 [entryType](https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype)
-attribute is `"layoutShift"`.
+attribute is `"layout-shift"`.
 
 The developer can compute the DCLS score by summing the LS scores:
 
 ```javascript
 addEventListener("load", () => {
-  DCLS = performance.getEntriesByType("layoutShift").reduce(
-      (score, entry) => { return score + entry.value; }, 0);
   new PerformanceObserver((list) => {
       list.getEntries().forEach((entry) => { DCLS += entry.value; });
-  }).observe({entryTypes: ["layoutShift"]});
+  }).observe({type: "layout-shift", buffered: true});
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ A "final" DCLS score for the user's session can be reported by listening to the
 [visibilitychange event](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#event-visibilitychange),
 and using the value of `DCLS` at that time.
 
-A [demo page](https://output.jsbin.com/gemufev) illustrating the use of this
+A [demo page](https://output.jsbin.com/zajamil/quiet) illustrating the use of this
 code can be viewed in Chrome 76+ with the command-line flag
 `--enable-blink-features=LayoutInstabilityAPI`, or in Chrome 73-75 with the
 command-line flag `--enable-blink-features=LayoutJankAPI`.


### PR DESCRIPTION
Follow https://w3ctag.github.io/design-principles/#casing-rules
Also stop using getEntriesByType and rely on buffered flag (LayoutShift should ideally not be in the timeline since it should be fully supported by buffering.