### PR TITLE
Update explainer for move distance, input exclusion, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ addEventListener("load", () => {
 By passing `buffered: true` to
 [observe](https://w3c.github.io/performance-timeline/#dom-performanceobserver-observe),
 the observer is immediately notified of any layout shifts that occurred before
-it was registered.  (Layout shift entries are not available from the
+it was registered.  (Layout shift entries are *not* available from the
 [Performance Timeline](https://w3c.github.io/performance-timeline/#performance-timeline)
 through `getEntriesByType`.)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Overview
 
-Many websites suffer from "layout instability" - DOM elements shifting around
+Many websites suffer from **layout instability** - DOM elements shifting around
 due to content loading asynchronously.
 
 We propose a way for the user agent to measure layout instability during a
@@ -14,15 +14,20 @@ new interface in the
 
 Each animation frame (a.k.a.
 "[rendering update](https://html.spec.whatwg.org/#update-the-rendering)")
-computes a *layout shift* (LS) score approximating the severity of visible
+computes a **layout shift (LS) score** approximating the severity of visible
 layout instability in the document during that frame.  An animation frame with
 no layout instability has an LS score of 0.  Higher LS scores correspond to
 greater instability.
 
+The LS score is based on a set of [shifting elements](#Shifting-Elements) and two
+intermediate values, the [impact fraction](#Impact-Fraction) and the
+[distance fraction](#Distance-Fraction).
+
 ### Shifting Elements
 
-A "shifting element" is one whose visual representation starts in a
-significantly different location than it did in the previous animation frame.
+A **shifting element** is one whose visual representation starts in a
+significantly different location than it did in the previous animation frame
+(for a reason other than [transform change](#Transform-Changes)).
 "Starts" refers here to the element's
 [flow-relative](https://www.w3.org/TR/css-writing-modes-4/#flow-relative) offset
 in the document.
@@ -45,15 +50,32 @@ Note that:
   a shifting element.
 
 * An element whose start location changes by less than 3 CSS pixels is not a
-  shifting element.
+  shifting element.  This threshold was chosen to avoid penalizing trivial
+  movements.  It also allows some animations (but a broader allowance is
+  described in "Transform Changes" below).
 
-### Impact Region
+### Transform Changes
 
-The "impact region" of an animation frame is the geometric union of the
+Changing an element's [transform](https://developer.mozilla.org/en-US/docs/Web/CSS/transform)
+affects its visual representation.  However, because
+
+* transform changes don't reflow surrounding content,
+* transform changes are a common target of fluid animations, and
+* animated transform changes are easily rendered with hardware-accelerated
+  compositing on a separate thread from the browser's layout and script
+  execution tasks,
+
+the layout instability metric doesn't treat transform-changing elements, or
+their descendants, as shifting elements (unless their layout is affected in some
+other way at the same time).
+
+### Impact Fraction
+
+The **impact region** of an animation frame is the geometric union of the
 previous-frame and current-frame visual representations, intersected with the
 viewport, of all shifting elements in that frame.
 
-The "impact fraction" of an animation frame is the fraction of the viewport that
+The **impact fraction** of an animation frame is the fraction of the viewport that
 is occupied by the impact region.
 
 ![Illustration of a shifting element on a device, with the impact region
@@ -62,47 +84,46 @@ highlighted](https://i.imgur.com/XN7xdKF.png)
 *Example: An element which occupies half the viewport shifts by a distance equal
 to half its height.  The impact fraction for this animation frame is 0.75.*
 
-In general, the layout shift (LS) score is equal to the impact fraction.
+### Distance Fraction
 
-TODO(skobes): describe distance fraction proposal
+The **move distance** of a shifting element is the distance it has moved on
+the horizontal or vertical axis (whichever is greater).
 
-However, if the user has generated certain
-[UI events](https://www.w3.org/TR/uievents/) within the past 500 ms, the LS
-score is 0.  This allows the page to modify its layout in response to the
-event.  The event types that trigger this exception include taps, key presses,
-and mouse clicks, but not mousemove or events that cause scrolling.
+The **distance fraction** of an animation frame is the greatest move distance
+of any shifting element in that frame, divided by the width or height
+(whichever is greater) of the viewport.
+
+![Illustration of shifting elements on a device, with their move distances
+indicated by arrows](https://i.imgur.com/qeks8UK.png)
+
+*Example: The most-shifted element moved a distance of one quarter of the
+viewport.  The distance fraction for this animation frame is 0.25.*
+
+The intent of incorporating the distance fraction into the LS score calculation
+is to avoid overly penalizing cases where large elements shift by small
+distances.
+
+### LS Score Calculation
+
+The layout shift (LS) score is equal to the impact fraction multiplied by the
+distance fraction.
 
 The user agent may trade off precision for efficiency in the computation of
 LS scores.  It is intended that the LS score have a correspondence to the
 perceptual severity of the instability, but not that all user agents produce
 exactly the same LS scores for a given page.
 
-### Cumulative Scores
-
-The user agent can compute a *document cumulative layout shift* (DCLS) score as
-the sum of the document's LS scores for each animation frame that has occurred
-during the browsing session.  The DCLS score is 0 when the document begins
-loading, and grows whenever layout instability occurs.  The DCLS score does not
-account for layout instability inside descendant browsing contexts, such as
-those created by `<iframe>` elements.
-
-The user agent can compute a *cumulative layout shift* (CLS) score for a
-[top-level browsing context](https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context)
-by summing the LS scores of the top-level browsing context to the weighted LS
-scores of its descendant browsing contexts.  In performing this aggregation,
-the LS score of a layout shift in an `<iframe>` should be weighted by the
-fraction of the top-level viewport the `<iframe>` occupies at the time the
-layout shift occurs.
-
 ### Performance API
 
-Animation frames with non-zero layout shift (LS) scores will notify a registered
+Animation frames with non-zero LS scores will notify a registered
 [PerformanceObserver](https://w3c.github.io/performance-timeline/#the-performanceobserver-interface).
 The observer's callback receives one or more `LayoutShift` entries:
 
 ```idl
 interface LayoutShift : PerformanceEntry {
     readonly attribute double value;
+    readonly attribute boolean hadRecentInput;
+    readonly attribute DOMHighResTimeStamp lastInputTime;
 };
 ```
 
@@ -110,22 +131,75 @@ The entry's `value` attribute is the LS score.  Its
 [entryType](https://w3c.github.io/performance-timeline/#dom-performanceentry-entrytype)
 attribute is `"layout-shift"`.
 
+The `hadRecentInput` and `lastInputTime` attributes are described in
+[Recent Input Exclusion](#Recent-Input-Exclusion).
+
+### Cumulative Scores
+
+The user agent can compute a **document cumulative layout shift** (DCLS) score
+as the sum of the document's LS scores for each animation frame that has occurred
+during the browsing session.  The DCLS score is 0 when the document begins
+loading, and grows whenever layout instability occurs.  The DCLS score does not
+account for layout instability inside descendant browsing contexts, such as
+those created by `<iframe>` elements.
+
+The user agent can compute a **cumulative layout shift** (CLS) score for a
+[top-level browsing context](https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context)
+by summing the LS scores of the top-level browsing context to the weighted LS
+scores of its descendant browsing contexts.  In performing this aggregation,
+the LS score of a layout shift in an `<iframe>` should be weighted by the
+fraction of the top-level viewport the `<iframe>` occupies at the time the
+layout shift occurs.
+
+The DCLS and CLS scores are not directly exposed by the [Performance API](#Performance-API),
+but we hope to make it easy for developers to construct these from the LS scores.
+
+### Recent Input Exclusion
+
+In calculating DCLS and CLS scores, developers and user agents may wish to
+exclude LS scores from animation frames that occur after recent
+[UI events](https://www.w3.org/TR/uievents/) events such as taps, key presses,
+and mouse clicks.  This allows the page to modify its layout in response to
+the event.
+
+To facilitate this exclusion, the `LayoutShift` entry has attributes
+indicating when such input last occurred, and whether it should be considered
+"recent" for the purpose of the exclusion.
+
+The `hadRecentInput` attribute is `true` when the last input occurred within
+the past 500 ms.  It should be treated as a hint to ignore the layout shift in
+calculating the DCLS and CLS scores.  This threshold was chosen to allow the
+page to make asynchronous rendering updates as a result of the input, as long
+as they occur without excessive delay. Developers wishing to implement a
+different threshold can do so by examining the `lastInputTime`.
+
+Events caused by pointer movement or scrolling do not count as "input" for the
+purpose of the recent input exclusion and the input-related attributes on the
+`LayoutShift` entry.
+
+### Computing DCLS with the API
+
 The developer can compute the DCLS score by summing the LS scores:
 
 ```javascript
 addEventListener("load", () => {
-  let DCLS = 0;
-  new PerformanceObserver((list) => {
-      list.getEntries().forEach((entry) => { DCLS += entry.value; });
-  }).observe({type: "layout-shift", buffered: true});
+    let DCLS = 0;
+    new PerformanceObserver((list) => {
+        list.getEntries().forEach((entry) => {
+            if (entry.hadRecentInput)
+                return;  // Ignore shifts after recent input.
+            DCLS += entry.value;
+        });
+    }).observe({type: "layout-shift", buffered: true});
 });
 ```
 
-The observer is only notified of layout instability that occurs after it is
-registered.  The `getEntriesByType` method retrieves buffered entries for layout
-shifts that has already occurred.  These entries are only buffered until the
-`load` event fires.  Layout instability that occurs after the `load` event can
-only be seen by the `PerformanceObserver`.
+By passing `buffered: true` to
+[observe](https://w3c.github.io/performance-timeline/#dom-performanceobserver-observe),
+the observer is immediately notified of any layout shifts that occurred before
+it was registered.  (Layout shift entries are not available from the
+[Performance Timeline](https://w3c.github.io/performance-timeline/#performance-timeline)
+through `getEntriesByType`.)
 
 A "final" DCLS score for the user's session can be reported by listening to the
 [visibilitychange event](https://developers.google.com/web/updates/2018/07/page-lifecycle-api#event-visibilitychange),

--- a/README.md
+++ b/README.md
@@ -121,9 +121,9 @@ The observer's callback receives one or more `LayoutShift` entries:
 
 ```idl
 interface LayoutShift : PerformanceEntry {
-    readonly attribute double value;
-    readonly attribute boolean hadRecentInput;
-    readonly attribute DOMHighResTimeStamp lastInputTime;
+    double value;
+    boolean hadRecentInput;
+    DOMHighResTimeStamp lastInputTime;
 };
 ```
 


### PR DESCRIPTION
This PR makes a number of updates to the layout instability metric explainer:

- Put key terms in bold at their point of definition.
- Describe move distance and distance fraction.
- Describe exclusion of transform changes.
- Clarify rationale for 3px threshold.
- Add hadRecentInput and lastInputTime to LayoutShift.
- Describe recent input exclusion.
- Check hadRecentInput in sample code (matching demo).
- Explain buffered flag, don't suggest getEntriesByType.