### PR TITLE
Update spec for input exclusion attributes.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -19,7 +19,7 @@ urlPrefix: https://dom.spec.whatwg.org/; spec: DOM;
     type: dfn; url: #interface-element; text: element
     type: dfn; url: #concept-shadow-including-descendant; text: shadow-including descendants;
 urlPrefix: https://www.w3.org/TR/css-writing-modes-4/; spec: CSS-WRITING-MODES-4;
-    type: dfn; url: #flow-relative; text: flow-relative offset; 
+    type: dfn; url: #flow-relative; text: flow-relative offset;
 urlPrefix: https://w3c.github.io/performance-timeline/; spec: PERFORMANCE-TIMELINE-2;
     type: interface; url: #the-performanceentry-interface; text: PerformanceEntry;
     type: attribute; for: PerformanceEntry;
@@ -45,11 +45,11 @@ urlPrefix: https://w3c.github.io/hr-time/; spec: HR-TIME-2;
     type: attribute; for: WindowOrWorkerGlobalScope;
         text: performance; url: #dom-windoworworkerglobalscope-performance;
 urlPrefix: https://www.w3.org/TR/CSS21/visuren.html; spec: CSS21;
-    type: dfn; url: #viewport; text: viewport; 
+    type: dfn; url: #viewport; text: viewport;
 urlPrefix: https://w3c.github.io/paint-timing/; spec: PAINT-TIMING;
     type: dfn; url: #mark-paint-timing; text: mark paint timing;
 urlPrefix: https://www.w3.org/TR/css-box-3/; spec: CSS-BOX-3;
-    type: dfn; url: #border-box; text: border box; 
+    type: dfn; url: #border-box; text: border box;
 urlPrefix: https://www.w3.org/TR/css-break-3/; spec: CSS-BREAK-3;
     type: dfn; url: #box-fragment; text: box fragment;
 urlPrefix: https://www.w3.org/TR/cssom-view-1/; spec: CSSOM-VIEW-1;
@@ -90,7 +90,7 @@ Usage example {#example}
     });
 
     // Register observer for layout shift notifications
-    observer.observe({entryTypes: ["layoutShift"]});
+    observer.observe({type: "layout-shift", buffered: true});
 </pre>
 
 <div class="non-normative">
@@ -114,18 +114,15 @@ The <dfn export>visual representation</dfn> of a <a href="https://www.w3.org/TR/
 <pre class="idl">
     interface LayoutShift : PerformanceEntry {
       readonly attribute long value;
+      readonly attribute boolean hadRecentInput;
+      readonly attribute DOMHighResTimeStamp lastInputTime;
     };
 </pre>
 
-{{LayoutShift}} extends the following attributes of {{PerformanceEntry}} interface:
+All attributes have the values assigned to them when the {{LayoutShift}} entry is constructed
+in <a>Compute the layout shift</a>.
 
-* The {{PerformanceEntry/name}} attribute must return the {{DOMString}} <code>"layout-shift"</code>
-* The {{PerformanceEntry/entryType}} attribute's getter must return <code>"layoutShift"</code>.
-* The {{PerformanceEntry/startTime}} attribute's getter must return the value it was initialized to.
-* The {{PerformanceEntry/duration}} attribute's getter must return 0.
-* The <dfn attribute for=LayoutShift>value</dfn> attribute's getter must return the value computed by <a>Compute the layout shift</a>.
-
-Note: A user agent implementing {{LayoutShift}} would need to include <code>"layoutShift"</code> in {{PerformanceObserver/supportedEntryTypes}} for {{Window}} contexts. This allows developers to detect support for layout instability.
+A user agent implementing the Layout Instability API must include <code>"layout-shift"</code> in {{PerformanceObserver/supportedEntryTypes}} for {{Window}} contexts. This allows developers to detect support for layout instability.
 
 Processing model {#sec-processing-model}
 ========================================
@@ -156,12 +153,12 @@ Evaluate layout instability {#sec-eval-layout-instability}
     1. Let <var>elements</var> be the set of <a>shadow-including descendants</a> of the <var>doc</var>.
     1. Let <var>unstableElements</var> be an empty list.
     1. Let <var>totalWidth</var> be the current <a>visual viewport width</a>.
-    1. Let <var>totalHeight</var> be the current <a>visual viewport height</a>. 
+    1. Let <var>totalHeight</var> be the current <a>visual viewport height</a>.
     1. Let <var>viewportDistance</var> be max(<var>totalWidth</var>, <var>totalHeight</var>).
     1. For each <var>element</var> of <var>elements</var>:
         1. Set <var>element</var>'s <a>current frame starting point</a> to the <a>starting point</a> of <var>element</var>.
         1. Set <var>element</var>'s <a>current visual representation</a> to the <a>visual representation</a> of <var>element</var>.
-        1. Let <var>unstable</var> be the boolean returned from calling <a>identify an unstable element</a> with <var>element</var>’s <a>current frame starting point</a> and <a>previous frame starting point</a>. 
+        1. Let <var>unstable</var> be the boolean returned from calling <a>identify an unstable element</a> with <var>element</var>’s <a>current frame starting point</a> and <a>previous frame starting point</a>.
         1. Set <var>element</var>'s <var>shiftFraction</var> to:
             1. 0 if <a>previous frame starting point</a> is null.
             1. The max distance the element has moved in any direction, which is computed as follows:
@@ -181,7 +178,7 @@ Compute the layout shift {#sec-compute-layout-shift}
 -----------------------------------------------------
 
 <div algorithm="compute the layout shift">
-    When asked to to <dfn export>compute the layout shift</dfn>, with <var>unstableElements</var>, a list of tuples, one for each impacted <a>element</a> on the page, as input, run the following steps:
+    When asked to <dfn export>compute the layout shift</dfn>, with <var>unstableElements</var>, a list of tuples, one for each impacted <a>element</a> on the page, as input, run the following steps:
 
     1. Let <var>impactedRegion</var> be a two-dimensional geometric region which is initially empty (that is, it contains no points).
     1. Let <var>maxShiftFraction</var> be initially set to 0.
@@ -190,18 +187,44 @@ Compute the layout shift {#sec-compute-layout-shift}
         1. Set <var>maxShiftFraction</var> to <var>shiftFraction</var> if <var>tuple</var>’s <var>shiftFraction</var> > <var>maxShiftFraction</var>.
     1. Subtract from <var>impactedRegion</var> all points that lie outside of the <a>viewport</a>.
     1. Let <var>impactedFraction</var> be the area of the <var>impactedRegion</var> divided by the area of the current <a>viewport</a>.
-    1. Set <var>layoutShift</var> to the <var>impactedFraction</var> multiplied by the <var>maxShiftFraction</var>.  
+    1. Set <var>layoutShift</var> to the <var>impactedFraction</var> multiplied by the <var>maxShiftFraction</var>.
     1. If <var>layoutShift</var> is greater than 0:
         1. Create a new {{LayoutShift}} object |newEntry|.
         1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to <code>"layout-shift"</code>.
-        1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to <code>"layoutShift"</code>.
+        1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to <code>"layout-shift"</code>.
         1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to <a>current high resolution time</a>.
         1. Set |newEntry|'s {{PerformanceEntry/duration}} attribute to 0.
-        1. Set |newEntry|'s {{LayoutShift/value}} attribute to <var>layoutShift</var>.
+        1. Set |newEntry|'s <dfn attribute for=LayoutShift>value</dfn> attribute to <var>layoutShift</var>.
+        1. Set |newEntry|'s <dfn attribute for=LayoutShift>lastInputTime</dfn> attribute
+            to the time of the most recent <a>excluding input</a>, or 0 if no excluding input has occurred
+            during the browsing session.
+        1. Set |newEntry|'s <dfn attribute for=LayoutShift>hadRecentInput</dfn> attribute
+            to <code>true</code> if {{LayoutShift/lastInputTime}} is less than 500 milliseconds in the past,
+            and <code>false</code> otherwise.
         1. <a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">Queue the PerformanceEntry</a> |newEntry| object.
 </div>
 
 NOTE: This computation ensures that the layout shift takes into account both the fraction of the viewport that has been impacted by layout stability as well as the greatest impact to any given element in the viewport.  This is to recognize that a large element that moves only a small distance can have a small impact on the perceived stability of the page.
+
+Input Exclusion {#sec-input-exclusion}
+--------------------------------------
+
+An <dfn export>excluding input</dfn> is any event from an input device which signals a user's
+active interaction with the page, or any event which directly changes the size of the <a>viewport</a>.
+
+Excluding inputs generally include <a href="https://www.w3.org/TR/uievents/#event-type-mousedown">mousedown</a>,
+<a href="https://www.w3.org/TR/uievents/#keydown">keydown</a>, and
+<a href="https://www.w3.org/TR/pointerevents/#the-pointerdown-event">pointerdown</a>.
+However, an event whose only effect is to begin or update a fling or scroll gesture
+is not an excluding input.
+
+The user agent may delay the reporting of layout shifts after a
+<a href="https://www.w3.org/TR/pointerevents/#the-pointerdown-event">pointerdown</a> event
+until such time as it is known that the event does not begin a fling or scroll gesture.
+
+The <a href="https://www.w3.org/TR/uievents/#event-type-mousemove">mousemove</a> and
+<a href="https://www.w3.org/TR/pointerevents/#the-pointermove-event">pointermove</a>
+events are also not excluding inputs.
 
 Identify an unstable element {#sec-identify-unstable-element}
 --------------------------------------------------------------
@@ -213,7 +236,8 @@ Identify an unstable element {#sec-identify-unstable-element}
     1. If <var>element</var>’s <a>previous frame starting point</a> does not equal <var>element</var>’s <a>current frame starting point</a> and they differ by 3 or more pixel units in the horizontal or vertical direction, return true.
     1. Return false.
 
-NOTE: Updating an element's CSS transform doesn't cause it to be an unstable element.
+But (notwithstanding the above), no element should be treated as unstable
+solely due to a change in the <a href="https://www.w3.org/TR/css-transforms-1/#transform-property">transform</a> of that element or of any other element.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -210,7 +210,7 @@ Input Exclusion {#sec-input-exclusion}
 --------------------------------------
 
 An <dfn export>excluding input</dfn> is any event from an input device which signals a user's
-active interaction with the page, or any event which directly changes the size of the <a>viewport</a>.
+active interaction with the document, or any event which directly changes the size of the <a>viewport</a>.
 
 Excluding inputs generally include <a href="https://www.w3.org/TR/uievents/#event-type-mousedown">mousedown</a>,
 <a href="https://www.w3.org/TR/uievents/#keydown">keydown</a>, and


### PR DESCRIPTION
Update the spec to reflect the new `hadRecentInput` and `lastInputTime` attributes on the `LayoutShift` interface.

Also, rename the entry type from "layoutShift" to "layout-shift", and add the buffered flag to the usage example.

Also, update the wording about the transform exclusion, and make it normative instead of a note.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/skobes/layout-instability/pull/17.html" title="Last updated on Jul 16, 2019, 3:36 PM UTC (4bb6144)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/17/85acb05...skobes:4bb6144.html" title="Last updated on Jul 16, 2019, 3:36 PM UTC (4bb6144)">Diff</a>