### PR TITLE
Refactor the Layout Instability API spec.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -44,8 +44,6 @@ urlPrefix: https://w3c.github.io/hr-time/; spec: HR-TIME-2;
     type: dfn; text: current high resolution time; url: #dfn-current-high-resolution-time;
     type: attribute; for: WindowOrWorkerGlobalScope;
         text: performance; url: #dom-windoworworkerglobalscope-performance;
-urlPrefix: https://www.w3.org/TR/CSS21/visuren.html; spec: CSS21;
-    type: dfn; url: #viewport; text: viewport;
 urlPrefix: https://w3c.github.io/paint-timing/; spec: PAINT-TIMING;
     type: dfn; url: #mark-paint-timing; text: mark paint timing;
 urlPrefix: https://www.w3.org/TR/css-box-3/; spec: CSS-BOX-3;
@@ -54,6 +52,7 @@ urlPrefix: https://www.w3.org/TR/css-break-3/; spec: CSS-BREAK-3;
     type: dfn; url: #box-fragment; text: box fragment;
 urlPrefix: https://www.w3.org/TR/cssom-view-1/; spec: CSSOM-VIEW-1;
     type: dfn; url: #css-pixels; text: CSS pixels;
+    type: dfn; url: #viewport; text: viewport;
 urlPrefix: https://www.w3.org/TR/css-values-4/; spec: CSS-VALUES-4;
     type: dfn; url: #pixel-unit; text: pixel units;
 urlPrefix: https://www.w3.org/TR/CSS2/visudet.html; spec: CSS2;
@@ -61,23 +60,33 @@ urlPrefix: https://www.w3.org/TR/CSS2/visudet.html; spec: CSS2;
 urlPrefix: https://wicg.github.io/visual-viewport/index.html; spec: VISUAL-VIEWPORT;
     type: dfn; url: #dom-visualviewport-width; text: visual viewport width;
     type: dfn; url: #dom-visualviewport-height; text: visual viewport height;
+urlPrefix: https://www.w3.org/TR/css-text-3/; spec: CSS-TEXT-3;
+    type: dfn; url: #line-breaking; text: line box;
 </pre>
+<pre class=link-defaults>
+spec:css-transforms-1; type:dfn; text:local coordinate system
+spec:css-break-4; type:dfn; text:fragment
+</pre>
+
+<div class="non-normative">
 
 Introduction {#sec-intro}
 =====================
 
-<div class="non-normative">
-
 <em>This section is non-normative.</em>
 
-The shifting of DOM elements on a webpage detracts from the user's experience, and occurs frequently on the web today.
-This shifting is often due to content loading asynchronously and displacing other elements on the page.
-The layout instability metric identifies these unstable pages by computing a value (the "layout shift") for each animation frame on the page, allowing the developer to compute an overall instability score for the page.
+The shifting of DOM elements on a webpage detracts from the user's experience,
+and occurs frequently on the web today. This shifting is often due to content
+loading asynchronously and displacing other elements on the page.
 
-</div>
+The layout Instability API identifies these unstable pages by reporting a value
+(the "layout shift") for each animation frame in the user's session, allowing
+the developer to compute a cumulative layout shift score for the page.
 
 Usage example {#example}
 ------------------------
+
+<em>This section is non-normative.</em>
 
 <pre class="example highlight">
     var observer = new PerformanceObserver(function(list) {
@@ -93,151 +102,226 @@ Usage example {#example}
     observer.observe({type: "layout-shift", buffered: true});
 </pre>
 
-<div class="non-normative">
+End of session signal {#end-of-session}
+---------------------------------------
 
 <em>This section is non-normative.</em>
 
-<h4 dfn>End of session signal</h4>
-A "final" penalty for the user's session can be reported by listening to the <a href="https://developers.google.com/web/updates/2018/07/page-lifecycle-api#event-visibilitychange">visibilitychange event</a>, and factoring in that last value at that time.
+The developer can compute a cumulative layout shift score by summing the layout
+shift values as they are reported to the observer.
+
+A "final" score for the user's session can be reported by listening to the
+<a href="https://developers.google.com/web/updates/2018/07/page-lifecycle-api#event-visibilitychange">visibilitychange event</a>,
+and taking the value of the cumulative layout shift score at that time.
 
 </div>
 
 Terminology {#sec-terminology}
 ==============================
-An <a>element</a>’s <dfn export>starting point</dfn> refers to the <a>element</a>'s <a>flow-relative offset</a> in the coordinate space of the <a>initial containing block</a> of the current document measured in <a>pixel units</a>.
 
-The <dfn export>visual representation</dfn> of a <a href="https://www.w3.org/TR/html401/struct/global.html#h-7.5.3">block-level</a> <a>element</a> is its <a>border box</a>. The <a>visual representation</a> of an <a href="https://www.w3.org/TR/html401/struct/global.html#h-7.5.3">inline element</a> is the geometric union of its <a>box fragment</a>s.
+Basic Concepts {#sec-basic-concepts}
+------------------------------------
 
-{{LayoutShift}} interface {#sec-layout-shift}
-=======================================
+The <dfn export>starting point</dfn> of a {{Node}} |N| in a coordinate space |C|
+is defined as follows:
 
-<pre class="idl">
-    interface LayoutShift : PerformanceEntry {
-      readonly attribute long value;
-      readonly attribute boolean hadRecentInput;
-      readonly attribute DOMHighResTimeStamp lastInputTime;
-    };
-</pre>
+* If |N| is an {{Element}} which generates one or more <a>boxes</a>, the
+    starting point of |N| in |C| is the two-dimensional offset in <a>pixel
+    units</a> from the origin of |C| to the <a>flow-relative</a> starting corner
+    of the first <a>fragment</a> of the <a>principal box</a> of |N|.
 
-All attributes have the values assigned to them when the {{LayoutShift}} entry is constructed
-in <a>Compute the layout shift</a>.
+* If |N| is a <a>text node</a>, the starting point of |N| in |C| is the
+    two-dimensional offset in <a>pixel units</a> from the origin of C to the
+    <a>flow-relative</a> starting corner of the first <a>line box</a> generated
+    by |N|.
 
-A user agent implementing the Layout Instability API must include <code>"layout-shift"</code> in {{PerformanceObserver/supportedEntryTypes}} for {{Window}} contexts. This allows developers to detect support for layout instability.
+The <dfn export>visual representation</dfn> of a {{Node}} |N| is defined as
+follows:
 
-Processing model {#sec-processing-model}
-========================================
+* If |N| is an {{Element}} which generates one or more <a>boxes</a>, the visual
+    representation of |N| is the set of all points that lie within the bounds of
+    any <a>fragment</a> of any <a>box</a> generated by |N|, in the coordinate
+    space of the <a>viewport</a>, excluding any points that lie outside of the
+    <a>viewport</a>.
 
-Modifications to the HTML specification {#sec-modifications-HTML-spec}
---------------------------------------------------------
+* If |N| is a <a>text node</a>, the visual representation of |N| is the set of
+    all points that lie within the bounds of any <a>line box</a> generated by
+    |N|, in the coordinate space of the <a>viewport</a>, excluding any points
+    that lie outside of the <a>viewport</a>.
 
-<em>This section will be removed once the <a href=https://html.spec.whatwg.org/multipage>HTML specification</a> has been modified.</em>
+A condition holds <dfn export>in the previous frame</dfn> if it was true at the
+point in time immediately after the most recently completed invocation of the
+<a>report the layout shift</a> algorithm.
 
-For each <a>element</a>, there is a:
-* <dfn>current frame starting point</dfn> which is initially set to <code>null</code>.
-* <dfn>previous frame starting point</dfn> which is initially set to <code>null</code>.
-* <dfn>current visual representation</dfn> which is initially set to <code>null</code>.
-* <dfn>previous visual representation</dfn> with is initially set to <code>null</code>.
+The <dfn export>previous frame starting point</dfn> of a {{Node}} |N| in a
+coordinate space |C| is the point which, <a>in the previous frame</a>, was the
+<a>starting point</a> of |N| in |C|.
 
-<div algorithm="additions to update rendering">
-    In the <a>update the rendering</a> step of the <a>event loop processing model</a>, add a step right after the step that calls <a>mark paint timing</a>:
+The <dfn export>previous frame visual representation</dfn> of a {{Node}} |N| is
+the set which, <a>in the previous frame</a>, was the <a>visual
+representation</a> of |N|.
 
-    1. For each fully active {{Document}} in <em>docs</em>, invoke the algorithm to <a>evaluate the layout instability</a> of that {{Document}}.
-</div>
+Unstable Nodes {#sec-unstable-nodes}
+------------------------------------
 
-Evaluate layout instability {#sec-eval-layout-instability}
---------------------------------------------------------
+A {{Node}} |N| <dfn export>has shifted</dfn> in a coordinate space |C| if the
+<a>starting point</a> of |N| in |C| differs from the <a>previous frame starting
+point</a> of |N| in |C| by 3 or more <a>pixel units</a> in either the horizontal
+or vertical direction.
 
-<div algorithm="evaluate the layout instability">
-    When asked to <dfn export>evaluate the layout instability</dfn> given an active {{Document}} <var>doc</var>, run the following steps:
+Otherwise, |N| <dfn export>has not shifted</dfn> in |C|.
 
-    1. Let <var>elements</var> be the set of <a>shadow-including descendants</a> of the <var>doc</var>.
-    1. Let <var>unstableElements</var> be an empty list.
-    1. Let <var>totalWidth</var> be the current <a>visual viewport width</a>.
-    1. Let <var>totalHeight</var> be the current <a>visual viewport height</a>.
-    1. Let <var>viewportDistance</var> be max(<var>totalWidth</var>, <var>totalHeight</var>).
-    1. For each <var>element</var> of <var>elements</var>:
-        1. Set <var>element</var>'s <a>current frame starting point</a> to the <a>starting point</a> of <var>element</var>.
-        1. Set <var>element</var>'s <a>current visual representation</a> to the <a>visual representation</a> of <var>element</var>.
-        1. Let <var>unstable</var> be the boolean returned from calling <a>identify an unstable element</a> with <var>element</var>’s <a>current frame starting point</a> and <a>previous frame starting point</a>.
-        1. Set <var>element</var>'s <var>shiftFraction</var> to:
-            1. 0 if <a>previous frame starting point</a> is null.
-            1. The max distance the element has moved in any direction, which is computed as follows:
-                1. Let <var>verticalDistance</var> be abs(<a>previous frame starting point</a>'s y-value - <a>current frame starting point</a>'s y-value) / <var>viewportDistance</var>.
-                1. Let <var>horizontalDistance</var> be abs(<a>previous frame starting point</a>'s x-value - <a>current frame starting point</a>'s x-value) / <var>viewportDistance</var>.
-                1. Take the max(<var>verticalDistance</var>, <var>horizontalDistance</var>).
-        1. If <var>unstable</var> is true, add a tuple to <var>unstableElements</var> with:
-            1. <a>current visual representation</a> of <var>element</var>
-            1. <a>previous visual representation</a> of <var>element</var>
-            1. <var>shiftFraction</var> of <var>element</var>:
-        1. Set <var>element</var>'s <a>previous frame starting point</a> point to <a>current frame starting point</a>.
-        1. Set <var>element</var>'s <a>previous visual representation</a> to the <a>current visual representation</a>.
-    1. Call <a>compute the layout shift</a> with <var>unstableElements</var>.
-</div>
+A {{Node}} |N| is <dfn export>unstable</dfn> if:
 
-Compute the layout shift {#sec-compute-layout-shift}
------------------------------------------------------
+* |N| is either
+    * an {{Element}} which generates one or more <a>boxes</a>, or
+    * a <a>text node</a>; and
+* |N| <a>has shifted</a> in the coordinate space of the <a>viewport</a>; and
+* |N| <a>has shifted</a> in the coordinate space of the <a>initial containing
+    block</a>; and
+* there does not exist an {{Element}} |P| such that
+    1. currently and <a>in the previous frame</a>, |P| is in the <a>containing
+        block chain</a> of |N|, and
+    1. currently and <a>in the previous frame</a>, |P| has a <a>local coordinate
+        system</a> or a <a>scrollable overflow region</a>, and
+    1. |P| is not <a>unstable</a>, and
+    1. |N| <a>has not shifted</a> in the coordinate space of the <a>local
+        coordinate system</a> or <a>scrollable overflow region</a> of |P|.
 
-<div algorithm="compute the layout shift">
-    When asked to <dfn export>compute the layout shift</dfn>, with <var>unstableElements</var>, a list of tuples, one for each impacted <a>element</a> on the page, as input, run the following steps:
+The <dfn export>unstable node set</dfn> of a {{Document}} |D| is the set
+containing every <a>unstable</a> <a>shadow-including descendant</a> of |D|.
 
-    1. Let <var>impactedRegion</var> be a two-dimensional geometric region which is initially empty (that is, it contains no points).
-    1. Let <var>maxShiftFraction</var> be initially set to 0.
-    1. For each tuple <var>tuple</var> in <var>unstableElements</var>:
-        1. If <a>previous visual representation</a> is not null, expand <var>impactedRegion</var> to additionally contain all points that lie within <var>tuple</var>'s <a>current visual representation</a>, <var>tuple</var>'s <a>previous visual representation</a>, or both.
-        1. Set <var>maxShiftFraction</var> to <var>shiftFraction</var> if <var>tuple</var>’s <var>shiftFraction</var> > <var>maxShiftFraction</var>.
-    1. Subtract from <var>impactedRegion</var> all points that lie outside of the <a>viewport</a>.
-    1. Let <var>impactedFraction</var> be the area of the <var>impactedRegion</var> divided by the area of the current <a>viewport</a>.
-    1. Set <var>layoutShift</var> to the <var>impactedFraction</var> multiplied by the <var>maxShiftFraction</var>.
-    1. If <var>layoutShift</var> is greater than 0:
-        1. Create a new {{LayoutShift}} object |newEntry|.
-        1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to <code>"layout-shift"</code>.
-        1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to <code>"layout-shift"</code>.
-        1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to <a>current high resolution time</a>.
-        1. Set |newEntry|'s {{PerformanceEntry/duration}} attribute to 0.
-        1. Set |newEntry|'s <dfn attribute for=LayoutShift>value</dfn> attribute to <var>layoutShift</var>.
-        1. Set |newEntry|'s <dfn attribute for=LayoutShift>lastInputTime</dfn> attribute
-            to the time of the most recent <a>excluding input</a>, or 0 if no excluding input has occurred
-            during the browsing session.
-        1. Set |newEntry|'s <dfn attribute for=LayoutShift>hadRecentInput</dfn> attribute
-            to <code>true</code> if {{LayoutShift/lastInputTime}} is less than 500 milliseconds in the past,
-            and <code>false</code> otherwise.
-        1. <a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">Queue the PerformanceEntry</a> |newEntry| object.
-</div>
+NOTE: In the first frame, the previous frame starting point does not exist for
+any node, and therefore the unstable node set is empty.
 
-NOTE: This computation ensures that the layout shift takes into account both the fraction of the viewport that has been impacted by layout stability as well as the greatest impact to any given element in the viewport.  This is to recognize that a large element that moves only a small distance can have a small impact on the perceived stability of the page.
+Layout Shift Value {#sec-layout-shift-value}
+--------------------------------------------
+
+The <dfn export>viewport base distance</dfn> is the greater of the <a>visual
+viewport width</a> or the <a>visual viewport height</a>.
+
+The <dfn export>move vector</dfn> of a {{Node}} |N| is the two-dimensional
+offset in <a>pixel units</a> from
+
+* the <a>previous frame starting point</a> of |N| in the coordinate space of the
+    <a>viewport</a>, to
+* the <a>starting point</a> of |N| in the coordinate space of the
+    <a>viewport</a>.
+
+The <dfn export>move distance</dfn> of a {{Node}} |N| is the greater of
+
+* the absolute value of the horizontal component of the <a>move vector</a> of
+    |N|, or
+* the absolute value of the vertical component of the <a>move vector</a> of |N|.
+
+The <dfn export>maximum move distance</dfn> of a {{Document}} |D| is the
+greatest <a>move distance</a> of any {{Node}} in the <a>unstable node set</a> of
+|D|, or 0 if the <a>unstable node set</a> of |D| is empty.
+
+The <dfn export>distance fraction</dfn> of a {{Document}} |D| is the lesser of
+
+* the <a>maximum move distance</a> of |D| divided by the <a>viewport base
+    distance</a>, or
+* 1.0.
+
+The <dfn export>impact region</dfn> of a {{Document}} |D| is the set containing
+
+* every point in the <a>visual representation</a> of any {{Node}} in the
+    <a>unstable node set</a> of |D|, and
+* every point in the <a>previous frame visual representation</a> of any {{Node}}
+    in the <a>unstable node set</a> of |D|.
+
+The <dfn export>impact fraction</dfn> of a {{Document}} |D| is the area of the
+<a>impact region</a> divided by the area of the <a>viewport</a>.
+
+The <dfn export>layout shift value</dfn> of a {{Document}} |D| is the <a>impact
+fraction</a> of |D| multiplied by the <a>distance fraction</a> of |D|.
+
+NOTE: The layout shift value takes into account both the fraction of the
+viewport that has been impacted by layout instability as well as the greatest
+distance by which any given element has moved. This recognizes that a large
+element which moves only a small distance can have a low impact on the perceived
+instability of the page.
 
 Input Exclusion {#sec-input-exclusion}
 --------------------------------------
 
-An <dfn export>excluding input</dfn> is any event from an input device which signals a user's
-active interaction with the document, or any event which directly changes the size of the <a>viewport</a>.
+An <dfn export>excluding input</dfn> is any event from an input device which
+signals a user's active interaction with the document, or any event which
+directly changes the size of the <a>viewport</a>.
 
-Excluding inputs generally include <a href="https://www.w3.org/TR/uievents/#event-type-mousedown">mousedown</a>,
+Excluding inputs generally include
+<a href="https://www.w3.org/TR/uievents/#event-type-mousedown">mousedown</a>,
 <a href="https://www.w3.org/TR/uievents/#keydown">keydown</a>, and
 <a href="https://www.w3.org/TR/pointerevents/#the-pointerdown-event">pointerdown</a>.
-However, an event whose only effect is to begin or update a fling or scroll gesture
-is not an excluding input.
+However, an event whose only effect is to begin or update a fling or scroll
+gesture is not an excluding input.
 
 The user agent may delay the reporting of layout shifts after a
 <a href="https://www.w3.org/TR/pointerevents/#the-pointerdown-event">pointerdown</a> event
-until such time as it is known that the event does not begin a fling or scroll gesture.
+until such time as it is known that the event does not begin a fling or scroll
+gesture.
 
 The <a href="https://www.w3.org/TR/uievents/#event-type-mousemove">mousemove</a> and
 <a href="https://www.w3.org/TR/pointerevents/#the-pointermove-event">pointermove</a>
 events are also not excluding inputs.
 
-Identify an unstable element {#sec-identify-unstable-element}
---------------------------------------------------------------
+{{LayoutShift}} interface {#sec-layout-shift}
+=======================================
 
-<div algorithm="identify an unstable element">
-    When asked to <dfn export>identify an unstable element</dfn>, given <var>element</var> as input, run the following steps:
+<pre class="idl">
+  interface LayoutShift : PerformanceEntry {
+    readonly attribute long value;
+    readonly attribute boolean hadRecentInput;
+    readonly attribute DOMHighResTimeStamp lastInputTime;
+  };
+</pre>
 
-    1. If <var>element</var>’s <a>previous frame starting point</a> is null, return false.
-    1. If <var>element</var>’s <a>previous frame starting point</a> does not equal <var>element</var>’s <a>current frame starting point</a> and they differ by 3 or more pixel units in the horizontal or vertical direction, return true.
-    1. Return false.
+All attributes have the values which are assigned to them by the steps to
+<a>report the layout shift</a>.
 
-But (notwithstanding the above), no element should be treated as unstable
-solely due to a change in the <a href="https://www.w3.org/TR/css-transforms-1/#transform-property">transform</a> of that element or of any other element.
+A user agent implementing the Layout Instability API MUST include
+<code>"layout-shift"</code> in {{PerformanceObserver/supportedEntryTypes}} for
+<a href="https://html.spec.whatwg.org/multipage/window-object.html#the-window-object">Window</a>
+contexts. This allows developers to detect support for the Layout Instability API.
+
+Processing model {#sec-processing-model}
+========================================
+
+Within the <a>update the rendering</a> step of the <a>event loop processing
+model</a>, a user agent implementing the Layout Instability API MUST perform the
+following step after the step that invokes the <a>mark paint timing</a>
+algorithm:
+
+1. For each fully active {{Document}} in <em>docs</em>, invoke the algorithm to
+    <a>report the layout shift</a> for that {{Document}}.
+
+Report the layout shift {#sec-report-layout-shift}
+-----------------------------------------------------
+
+<div algorithm="report the layout shift">
+When asked to <dfn export>report the layout shift</dfn> for an active
+{{Document}} |D|, run the following steps:
+
+1. If the current <a>layout shift value</a> of |D| is not 0:
+    1. Create a new {{LayoutShift}} object |newEntry|.
+    1. Set |newEntry|'s {{PerformanceEntry/name}} attribute to
+        <code>"layout-shift"</code>.
+    1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to
+        <code>"layout-shift"</code>.
+    1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to <a>current
+        high resolution time</a>.
+    1. Set |newEntry|'s {{PerformanceEntry/duration}} attribute to 0.
+    1. Set |newEntry|'s <dfn attribute for=LayoutShift>value</dfn> attribute to
+        the current <a>layout shift value</a> of |D|.
+    1. Set |newEntry|'s <dfn attribute for=LayoutShift>lastInputTime</dfn>
+        attribute to the time of the most recent <a>excluding input</a>, or 0 if
+        no excluding input has occurred during the browsing session.
+    1. Set |newEntry|'s <dfn attribute for=LayoutShift>hadRecentInput</dfn>
+        attribute to <code>true</code> if {{LayoutShift/lastInputTime}} is less
+        than 500 milliseconds in the past, and <code>false</code> otherwise.
+    1. <a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">Queue the PerformanceEntry</a>
+        |newEntry| object.
 
 </div>
 


### PR DESCRIPTION
For greater clarity, express logic principally through concept
definitions instead of algorithms.

Codify the CSS transform exclusion more precisely, and extend it to
scrolling.

Define visual representation for elements with reference to CSS
Display and Fragmentation specs for box and fragment concepts.

Define visual representation for text with reference to line boxes.

Specify that the first fragment determines the starting point.

General cleanup and simplification.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/skobes/layout-instability/pull/22.html" title="Last updated on Aug 13, 2019, 7:35 PM UTC (31c8721)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/22/4bb6144...skobes:31c8721.html" title="Last updated on Aug 13, 2019, 7:35 PM UTC (31c8721)">Diff</a>