### PR TITLE
Fix usage of takeRecords in example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -152,7 +152,7 @@ Usage example {#example}
 The layout shift score is only one signal, which correlates in an approximate
 manner with the user experience of "jumpiness".
 
-Developers have to avoid relying on the precise value of the layout shift score,
+Developers are advised to avoid relying on the precise value of the layout shift score,
 as the metric might evolve over time, and user agents might compromise precision
 in the interest of calculation efficiency.
 

--- a/index.bs
+++ b/index.bs
@@ -118,15 +118,19 @@ Usage example {#example}
     // Stores the current layout shift score for the page.
     let cumulativeLayoutShiftScore = 0;
 
-    // Detects new layout shift occurrences and updates the
-    // `cumulativeLayoutShiftScore` variable.
-    const observer = new PerformanceObserver((list) => {
-      for (const entry of list.getEntries()) {
+    function updateCLS(entries) {
+      for (const entry of entries) {
         // Only count layout shifts without recent user input.
         if (!entry.hadRecentInput) {
           cumulativeLayoutShiftScore += entry.value;
         }
       }
+    }
+
+    // Detects new layout shift occurrences and updates the
+    // `cumulativeLayoutShiftScore` variable.
+    const observer = new PerformanceObserver((list) => {
+      updateCLS(list.getEntries());
     });
 
     observer.observe({type: 'layout-shift', buffered: true});
@@ -136,7 +140,7 @@ Usage example {#example}
     document.addEventListener('visibilitychange', () => {
       if (document.visibilityState === 'hidden') {
         // Force any pending records to be dispatched.
-        observer.takeRecords();
+        updateCLS(observer.takeRecords());
 
         // Send the final score to your analytics back end
         // (assumes `sendToAnalytics` is defined elsewhere).
@@ -148,7 +152,7 @@ Usage example {#example}
 The layout shift score is only one signal, which correlates in an approximate
 manner with the user experience of "jumpiness".
 
-Developers should avoid relying on the precise value of the layout shift score,
+Developers have to avoid relying on the precise value of the layout shift score,
 as the metric might evolve over time, and user agents might compromise precision
 in the interest of calculation efficiency.
 


### PR DESCRIPTION
Fixes https://github.com/WICG/layout-instability/issues/30. Also fix a warning about not using 'must' in a non-normative section.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/pull/31.html" title="Last updated on Feb 26, 2020, 7:06 PM UTC (f92d80d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/31/ba0f51e...f92d80d.html" title="Last updated on Feb 26, 2020, 7:06 PM UTC (f92d80d)">Diff</a>