### PR TITLE
Add shifted element attribution (#11).

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -66,6 +66,8 @@ urlPrefix: https://www.w3.org/TR/geometry-1/; spec: GEOMETRY-1;
     type: dfn; url: #domrectreadonly; text: DOMRectReadOnly
 urlPrefix: https://www.w3.org/TR/geometry-1/; spec: GEOMETRY-1;
     type: dfn; url: #rectangle; text: Rectangle
+urlPrefix: https://wicg.github.io/element-timing/; spec: ELEMENT-TIMING;
+    type: dfn; url: #get-an-element; text: get an element;
 </pre>
 <pre class=link-defaults>
 spec:css-transforms-1; type:dfn; text:local coordinate system
@@ -102,6 +104,8 @@ the severity of layout instability for the lifetime of a page.
 End of session signal {#end-of-session}
 ---------------------------------------
 
+<em>This section is non-normative.</em>
+
 The developer can compute a cumulative layout shift score by summing the layout
 shift values as they are reported to the observer.
 
@@ -113,6 +117,8 @@ This strategy is illustrated in the usage example.
 
 Source attribution {#source-attribution}
 ----------------------------------------
+
+<em>This section is non-normative.</em>
 
 In addition to the layout shift value, the API reports a sampling of up to five
 DOM elements whose layout shifts most substantially contributed to the layout
@@ -133,6 +139,8 @@ occurrence of layout instability.
 
 Usage example {#example}
 ------------------------
+
+<em>This section is non-normative.</em>
 
 <pre class="example highlight">
     // Stores the current layout shift score for the page.
@@ -340,7 +348,7 @@ events are also not excluding inputs.
     readonly attribute long value;
     readonly attribute boolean hadRecentInput;
     readonly attribute DOMHighResTimeStamp lastInputTime;
-    readonly attribute FrozenArray&lt;LayoutShiftAttribution&gt; sources;
+    readonly attribute sequence&lt;LayoutShiftAttribution&gt; sources;
     [Default] object toJSON();
   };
 </pre>
@@ -418,32 +426,42 @@ Report the layout shift sources {#sec-report-layout-shift-sources}
 When asked to <dfn>report the layout shift sources</dfn> for an active
 {{Document}} |D|, run the following steps:
 
-1. Let |S| be any set which satisfies these constraints:
-    * Each member of |S| is in the <a>unstable node set</a> of |D|.
-    * |S| contains at least 1 member, and not more than 5 members.
-    * |S| does not contain two members |s1| and |s2| such that the
-        <a>node impact region</a> of |s1| is a subset of the
-        <a>node impact region</a> of |s2|.
-    * The <a>unstable node set</a> of |D| does not contain any member |u|
-        such that the area of the <a>node impact region</a> of |u| is
-        greater than the area of the <a>node impact region</a> of any
-        member of |S|.
-    * |S| does not contain a {{Node}} whose
-        <a href="https://dom.spec.whatwg.org/#concept-tree-root">root</a>
-        is a <a href="https://dom.spec.whatwg.org/#concept-shadow-root">shadow root</a>.
-1. Return a {{FrozenArray}} containing one {{LayoutShiftAttribution}} object
-    for each member |s| of |S|, created by running the algorithm to
-    <a>create the attribution</a> for |s|.
+1. Let |C| be an empty sequence of {{LayoutShiftAttribution}} objects.
+
+1. For each member |N| of the <a>unstable node set</a> of |D|, run these steps:
+
+    1. Let |NA| be the result of running the algorithm to
+        <a>create the attribution</a> for |N| and |D|.
+    1. If there exists any member |existing| of |C| such that the
+        <a>node impact region</a> of |N| is a subset of the
+        <a>node impact region</a> of |existing|, then do nothing.
+    1. Otherwise, if there exists any member |existing| of |C| such
+        that the <a>node impact region</a> of |existing| is a subset
+        of the <a>node impact region</a> of |N|, then replace
+        |existing| with |NA| in |C|.
+    1. Otherwise, if there are fewer than 5 members of |C|, then
+        append |NA| to |C|.
+    1. Otherwise, run these steps:
+
+        1. Let |smallest| be the first member of |C| whose
+            <a>node impact region</a> is not greater in area than
+            the <a>node impact region</a> of any other member of |C|.
+        1. If the area of the <a>node impact region</a> of |N| is
+            greater than the area of the <a>node impact region</a>
+            of |smallest|, then replace |smallest| with |NA| in |C|.
+
+1. Return |C|.
 
 </div>
 
 <div algorithm="create the attribution">
-When asked to <dfn>create the attribution</dfn> for a {{Node}} |N|,
-run the following steps:
+When asked to <dfn>create the attribution</dfn> for a {{Node}} |N|
+and an active {{Document}} |D|, run the following steps:
 
 1. Create a new {{LayoutShiftAttribution}} object |A|.
 1. Set the <dfn attribute for=LayoutShiftAttribution>node</dfn> attribute
-    of |A| to |N|.
+    of |A| to the result of running the <a>get an element</a>
+    algorithm with |N| and |D| as inputs.
 1. Set the <dfn attribute for=LayoutShiftAttribution>previousRect</dfn> attribute
     of |A| to the smallest <a>Rectangle</a> containing the <a>previous frame visual
     representation</a> of |N|.
@@ -451,6 +469,13 @@ run the following steps:
     of |A| to the smallest <a>Rectangle</a> containing the <a>visual
     representation</a> of |N|.
 1. Return |A|.
+
+Note: The use of the <a>get an element</a> algorithm above ensures that
+the <a href="#dom-layoutshiftattribution-node">node</a> attribute is null if the attributed node is no longer
+attached, or is inside a shadow root.
+
+Issue: The <a>get an element</a> algorithm should be moved out of the
+Element Timing spec and into a place more suitable for reuse here.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -451,13 +451,13 @@ When asked to <dfn>report the layout shift sources</dfn> for an active
 
 1. For each member |N| of the <a>unstable node set</a> of |D|, run these steps:
 
-    1. If there exists any member |existing| of |C| such that the
+    1. If there exists any member |existingNode| of |C| such that the
         <a>node impact region</a> of |N| is a subset of the
-        <a>node impact region</a> of |existing|, then continue.
-    1. Otherwise, if there exists any member |existing| of |C| such
-        that the <a>node impact region</a> of |existing| is a subset
+        <a>node impact region</a> of |existingNode|, then continue.
+    1. Otherwise, if there exists any member |existingNode| of |C| such
+        that the <a>node impact region</a> of |existingNode| is a subset
         of the <a>node impact region</a> of |N|, then <a href="https://infra.spec.whatwg.org/#list-replace">replace</a>
-        the first such member |existing| with |N| in |C|.
+        the first such member |existingNode| with |N| in |C|.
     1. Otherwise, if there are fewer than 5 members of |C|, then
         <a href="https://infra.spec.whatwg.org/#list-append">append</a> |N| to |C|.
     1. Otherwise, run these steps:

--- a/index.bs
+++ b/index.bs
@@ -62,6 +62,10 @@ urlPrefix: https://wicg.github.io/visual-viewport/index.html; spec: VISUAL-VIEWP
     type: dfn; url: #dom-visualviewport-height; text: visual viewport height;
 urlPrefix: https://www.w3.org/TR/css-text-3/; spec: CSS-TEXT-3;
     type: dfn; url: #line-breaking; text: line box;
+urlPrefix: https://www.w3.org/TR/geometry-1/; spec: GEOMETRY-1;
+    type: dfn; url: #domrectreadonly; text: DOMRectReadOnly
+urlPrefix: https://www.w3.org/TR/geometry-1/; spec: GEOMETRY-1;
+    type: dfn; url: #rectangle; text: Rectangle
 </pre>
 <pre class=link-defaults>
 spec:css-transforms-1; type:dfn; text:local coordinate system
@@ -108,6 +112,23 @@ A "final" score for the user's session can be reported by listening to the
 and taking the value of the cumulative layout shift score at that time.
 
 This strategy is illustrated in the usage example.
+
+Source attribution {#source-attribution}
+----------------------------------------
+
+<em>This section is non-normative.</em>
+
+In addition to the layout shift value, the API reports a sampling of up to five
+DOM elements whose layout shifts most substantially contributed to the layout
+shit value for an animation frame.
+
+It is possible that the true "root cause" of the instability will be one or more
+steps removed from the DOM elements that experience a layout shift. For example,
+a newly inserted element might cause a shift in content below it. The
+<a href="#dom-layoutshift-sources">sources</a>
+attribute will report only shifted elements, and not the inserted element.
+Nevertheless, we expect this reporting to be of significant value to developers
+who are attempting to diagnose an occurrence of layout instability.
 
 Usage example {#example}
 ------------------------
@@ -266,12 +287,14 @@ The <dfn export>distance fraction</dfn> of a {{Document}} |D| is the lesser of
     distance</a>, or
 * 1.0.
 
-The <dfn export>impact region</dfn> of a {{Document}} |D| is the set containing
+The <dfn export>node impact region</dfn> of a {{Node}} |N| is the set containing
 
-* every point in the <a>visual representation</a> of any {{Node}} in the
-    <a>unstable node set</a> of |D|, and
-* every point in the <a>previous frame visual representation</a> of any {{Node}}
-    in the <a>unstable node set</a> of |D|.
+* every point in the <a>visual representation</a> of |N|, and
+* every point in the <a>previous frame visual representation</a> of |N|.
+
+The <dfn export>impact region</dfn> of a {{Document}} |D| is the set containing
+every point in the <a>node impact region</a> of any {{Node}} in the
+<a>unstable node set</a> of |D|.
 
 The <dfn export>impact fraction</dfn> of a {{Document}} |D| is the area of the
 <a>impact region</a> divided by the area of the <a>viewport</a>.
@@ -317,6 +340,7 @@ events are also not excluding inputs.
     readonly attribute long value;
     readonly attribute boolean hadRecentInput;
     readonly attribute DOMHighResTimeStamp lastInputTime;
+    readonly attribute FrozenArray&lt;LayoutShiftAttribution&gt; sources;
     [Default] object toJSON();
   };
 </pre>
@@ -328,6 +352,18 @@ A user agent implementing the Layout Instability API MUST include
 <code>"layout-shift"</code> in {{PerformanceObserver/supportedEntryTypes}} for
 <a href="https://html.spec.whatwg.org/multipage/window-object.html#the-window-object">Window</a>
 contexts. This allows developers to detect support for the Layout Instability API.
+
+{{LayoutShiftAttribution}} interface {#sec-layout-shift-attribution}
+====================================================================
+
+<pre class="idl">
+  [Exposed=Window]
+  interface LayoutShiftAttribution {
+    readonly attribute Node node;
+    readonly attribute DOMRectReadOnly previousRect;
+    readonly attribute DOMRectReadOnly currentRect;
+  };
+</pre>
 
 Processing model {#sec-processing-model}
 ========================================
@@ -364,8 +400,51 @@ When asked to <dfn export>report the layout shift</dfn> for an active
     1. Set |newEntry|'s <dfn attribute for=LayoutShift>hadRecentInput</dfn>
         attribute to <code>true</code> if {{LayoutShift/lastInputTime}} is less
         than 500 milliseconds in the past, and <code>false</code> otherwise.
+    1. Set |newEntry|'s <dfn attribute for=LayoutShift>sources</dfn> attribute
+        to the result of invoking the algorithm to <a>report the layout shift
+        sources</a> for |D|.
     1. <a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">Queue the PerformanceEntry</a>
         |newEntry| object.
+
+</div>
+
+Report the layout shift sources {#sec-report-layout-shift-sources}
+------------------------------------------------------------------
+
+<div algorithm="report the layout shift sources">
+When asked to <dfn export>report the layout shift sources</dfn> for an active
+{{Document}} |D|, run the following steps:
+
+1. Let |S| be any set which satisfies these constraints:
+    * Each member of |S| is in the <a>unstable node set</a> of |D|.
+    * |S| contains at least 1 member, and not more than 5 members.
+    * |S| does not contain two members |s1| and |s2| such that the
+        <a>node impact region</a> of |s1| is a subset of the
+        <a>node impact region</a> of |s2|.
+    * The <a>unstable node set</a> of |D| does not contain any member |u|
+        such that the area of the <a>node impact region</a> of |u| is
+        greater than the area of the <a>node impact region</a> of any
+        member of |S|.
+1. Return a {{FrozenArray}} containing one {{LayoutShiftAttribution}} object
+    for each member |s| of |S|, created by running the algorithm to
+    <a>create the attribution</a> for |s|.
+
+</div>
+
+<div algorithm="create the attribution">
+When asked to <dfn export>create the attribution</dfn> for a {{Node}} |N|,
+run the following steps:
+
+1. Create a new {{LayoutShiftAttribution}} object |A|.
+1. Set the <dfn attribute for=LayoutShiftAttribution>node</dfn> attribute
+    of |A| to |N|.
+1. Set the <dfn attribute for=LayoutShiftAttribution>previousRect</dfn> attribute
+    to the smallest <a>Rectangle</a> containing the <a>previous frame visual
+    representation</a> of |N|.
+1. Set the <dfn attribute for=LayoutShiftAttribution>currentRect</dfn> attribute
+    to the smallest <a>Rectangle</a> containing the <a>visual
+    representation</a> of |N|.
+1. Return |A|.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -367,7 +367,7 @@ contexts. This allows developers to detect support for the Layout Instability AP
 <pre class="idl">
   [Exposed=Window]
   interface LayoutShiftAttribution {
-    readonly attribute Node node;
+    readonly attribute Node? node;
     readonly attribute DOMRectReadOnly previousRect;
     readonly attribute DOMRectReadOnly currentRect;
   };
@@ -384,10 +384,13 @@ that algorithm.
 
 Note: The use of the <a>get an element</a> algorithm ensures that
 the <a href="#dom-layoutshiftattribution-node">node</a> attribute
-is null if the attributed node is no longer attached, or is inside a shadow root.
+is null if the attributed node is no longer connected, or is inside a shadow root.
 
 Issue: The <a>get an element</a> algorithm should be moved out of the
 Element Timing spec and into a place more suitable for reuse here.
+
+Issue: The <a>get an element</a> algorithm should be generalized to accept
+{{Node}} instead of {{Element}}.
 
 The <a href="#dom-layoutshiftattribution-node">previousRect</a>
 and <a href="#dom-layoutshiftattribution-node">currentRect</a>
@@ -444,13 +447,13 @@ Report the layout shift sources {#sec-report-layout-shift-sources}
 When asked to <dfn>report the layout shift sources</dfn> for an active
 {{Document}} |D|, run the following steps:
 
-1. Let |C| be an empty <a>sequence</a> of {{Node}} objects.
+1. Let |C| be an empty <a href="https://infra.spec.whatwg.org/#list">list</a> of {{Node}} objects.
 
 1. For each member |N| of the <a>unstable node set</a> of |D|, run these steps:
 
     1. If there exists any member |existing| of |C| such that the
         <a>node impact region</a> of |N| is a subset of the
-        <a>node impact region</a> of |existing|, then do nothing.
+        <a>node impact region</a> of |existing|, then continue.
     1. Otherwise, if there exists any member |existing| of |C| such
         that the <a>node impact region</a> of |existing| is a subset
         of the <a>node impact region</a> of |N|, then <a href="https://infra.spec.whatwg.org/#list-replace">replace</a>

--- a/index.bs
+++ b/index.bs
@@ -373,7 +373,25 @@ contexts. This allows developers to detect support for the Layout Instability AP
   };
 </pre>
 
-All attributes have the values which are assigned to them by the steps to
+Each {{LayoutShiftAttribution}} is associated with a {{Node}} (its
+<dfn>associated node</dfn>).
+
+The getter of the <a href="#dom-layoutshiftattribution-node">node</a> attribute
+of a {{LayoutShiftAttribution}} instance |A| invokes the <a>get an element</a>
+algorithm with the <a>associated node</a> of |A|, and the <a>node document</a>
+of the <a>associated node</a> of |A|, as inputs, and returns the result of
+that algorithm.
+
+Note: The use of the <a>get an element</a> algorithm ensures that
+the <a href="#dom-layoutshiftattribution-node">node</a> attribute
+is null if the attributed node is no longer attached, or is inside a shadow root.
+
+Issue: The <a>get an element</a> algorithm should be moved out of the
+Element Timing spec and into a place more suitable for reuse here.
+
+The <a href="#dom-layoutshiftattribution-node">previousRect</a>
+and <a href="#dom-layoutshiftattribution-node">currentRect</a>
+attributes have the values which are assigned to them by the steps to
 <a>create the attribution</a>.
 
 Processing model {#sec-processing-model}
@@ -426,21 +444,19 @@ Report the layout shift sources {#sec-report-layout-shift-sources}
 When asked to <dfn>report the layout shift sources</dfn> for an active
 {{Document}} |D|, run the following steps:
 
-1. Let |C| be an empty sequence of {{LayoutShiftAttribution}} objects.
+1. Let |C| be an empty <a>sequence</a> of {{Node}} objects.
 
 1. For each member |N| of the <a>unstable node set</a> of |D|, run these steps:
 
-    1. Let |NA| be the result of running the algorithm to
-        <a>create the attribution</a> for |N| and |D|.
     1. If there exists any member |existing| of |C| such that the
         <a>node impact region</a> of |N| is a subset of the
         <a>node impact region</a> of |existing|, then do nothing.
     1. Otherwise, if there exists any member |existing| of |C| such
         that the <a>node impact region</a> of |existing| is a subset
-        of the <a>node impact region</a> of |N|, then replace
-        |existing| with |NA| in |C|.
+        of the <a>node impact region</a> of |N|, then <a href="https://infra.spec.whatwg.org/#list-replace">replace</a>
+        the first such member |existing| with |N| in |C|.
     1. Otherwise, if there are fewer than 5 members of |C|, then
-        append |NA| to |C|.
+        <a href="https://infra.spec.whatwg.org/#list-append">append</a> |N| to |C|.
     1. Otherwise, run these steps:
 
         1. Let |smallest| be the first member of |C| whose
@@ -448,20 +464,22 @@ When asked to <dfn>report the layout shift sources</dfn> for an active
             the <a>node impact region</a> of any other member of |C|.
         1. If the area of the <a>node impact region</a> of |N| is
             greater than the area of the <a>node impact region</a>
-            of |smallest|, then replace |smallest| with |NA| in |C|.
+            of |smallest|, then
+            <a href="https://infra.spec.whatwg.org/#list-replace">replace</a>
+            |smallest| with |N| in |C|.
 
-1. Return |C|.
+1. Return a <a>sequence</a> of {{LayoutShiftAttribution}} objects created
+    by running the algorithm to <a>create the attribution</a> once
+    for each member of |C|.
 
 </div>
 
 <div algorithm="create the attribution">
-When asked to <dfn>create the attribution</dfn> for a {{Node}} |N|
-and an active {{Document}} |D|, run the following steps:
+When asked to <dfn>create the attribution</dfn> for a {{Node}} |N|,
+run the following steps:
 
 1. Create a new {{LayoutShiftAttribution}} object |A|.
-1. Set the <dfn attribute for=LayoutShiftAttribution>node</dfn> attribute
-    of |A| to the result of running the <a>get an element</a>
-    algorithm with |N| and |D| as inputs.
+1. Set the <a>associated node</a> of |A| to |N|.
 1. Set the <dfn attribute for=LayoutShiftAttribution>previousRect</dfn> attribute
     of |A| to the smallest <a>Rectangle</a> containing the <a>previous frame visual
     representation</a> of |N|.
@@ -469,13 +487,6 @@ and an active {{Document}} |D|, run the following steps:
     of |A| to the smallest <a>Rectangle</a> containing the <a>visual
     representation</a> of |N|.
 1. Return |A|.
-
-Note: The use of the <a>get an element</a> algorithm above ensures that
-the <a href="#dom-layoutshiftattribution-node">node</a> attribute is null if the attributed node is no longer
-attached, or is inside a shadow root.
-
-Issue: The <a>get an element</a> algorithm should be moved out of the
-Element Timing spec and into a place more suitable for reuse here.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -102,8 +102,6 @@ the severity of layout instability for the lifetime of a page.
 End of session signal {#end-of-session}
 ---------------------------------------
 
-<em>This section is non-normative.</em>
-
 The developer can compute a cumulative layout shift score by summing the layout
 shift values as they are reported to the observer.
 
@@ -116,24 +114,25 @@ This strategy is illustrated in the usage example.
 Source attribution {#source-attribution}
 ----------------------------------------
 
-<em>This section is non-normative.</em>
-
 In addition to the layout shift value, the API reports a sampling of up to five
 DOM elements whose layout shifts most substantially contributed to the layout
-shit value for an animation frame.
+shift value for an animation frame.
 
-It is possible that the true "root cause" of the instability will be one or more
-steps removed from the DOM elements that experience a layout shift. For example,
-a newly inserted element might cause a shift in content below it. The
+It is possible that the true "root cause" of instability will be only
+indirectly related to the DOM element that experiences a layout shift.
+For example, if a newly inserted element shifts content below it, the
 <a href="#dom-layoutshift-sources">sources</a>
-attribute will report only shifted elements, and not the inserted element.
-Nevertheless, we expect this reporting to be of significant value to developers
-who are attempting to diagnose an occurrence of layout instability.
+attribute will report only the shifted elements, and not the inserted element.
+
+We do not believe it is feasible for the user agent to understand causes
+of instability at the level of indirection necessary for a meaningful "root
+cause" attribution. However, we expect that the more straightforward
+reporting of shifted elements presented in this API will nevertheless be
+of significant value to developers who are attempting to diagnose an
+occurrence of layout instability.
 
 Usage example {#example}
 ------------------------
-
-<em>This section is non-normative.</em>
 
 <pre class="example highlight">
     // Stores the current layout shift score for the page.
@@ -287,7 +286,8 @@ The <dfn export>distance fraction</dfn> of a {{Document}} |D| is the lesser of
     distance</a>, or
 * 1.0.
 
-The <dfn export>node impact region</dfn> of a {{Node}} |N| is the set containing
+The <dfn export>node impact region</dfn> of an <a>unstable</a> {{Node}} |N|
+is the set containing
 
 * every point in the <a>visual representation</a> of |N|, and
 * every point in the <a>previous frame visual representation</a> of |N|.
@@ -365,6 +365,9 @@ contexts. This allows developers to detect support for the Layout Instability AP
   };
 </pre>
 
+All attributes have the values which are assigned to them by the steps to
+<a>create the attribution</a>.
+
 Processing model {#sec-processing-model}
 ========================================
 
@@ -412,7 +415,7 @@ Report the layout shift sources {#sec-report-layout-shift-sources}
 ------------------------------------------------------------------
 
 <div algorithm="report the layout shift sources">
-When asked to <dfn export>report the layout shift sources</dfn> for an active
+When asked to <dfn>report the layout shift sources</dfn> for an active
 {{Document}} |D|, run the following steps:
 
 1. Let |S| be any set which satisfies these constraints:
@@ -425,6 +428,9 @@ When asked to <dfn export>report the layout shift sources</dfn> for an active
         such that the area of the <a>node impact region</a> of |u| is
         greater than the area of the <a>node impact region</a> of any
         member of |S|.
+    * |S| does not contain a {{Node}} whose
+        <a href="https://dom.spec.whatwg.org/#concept-tree-root">root</a>
+        is a <a href="https://dom.spec.whatwg.org/#concept-shadow-root">shadow root</a>.
 1. Return a {{FrozenArray}} containing one {{LayoutShiftAttribution}} object
     for each member |s| of |S|, created by running the algorithm to
     <a>create the attribution</a> for |s|.
@@ -432,17 +438,17 @@ When asked to <dfn export>report the layout shift sources</dfn> for an active
 </div>
 
 <div algorithm="create the attribution">
-When asked to <dfn export>create the attribution</dfn> for a {{Node}} |N|,
+When asked to <dfn>create the attribution</dfn> for a {{Node}} |N|,
 run the following steps:
 
 1. Create a new {{LayoutShiftAttribution}} object |A|.
 1. Set the <dfn attribute for=LayoutShiftAttribution>node</dfn> attribute
     of |A| to |N|.
 1. Set the <dfn attribute for=LayoutShiftAttribution>previousRect</dfn> attribute
-    to the smallest <a>Rectangle</a> containing the <a>previous frame visual
+    of |A| to the smallest <a>Rectangle</a> containing the <a>previous frame visual
     representation</a> of |N|.
 1. Set the <dfn attribute for=LayoutShiftAttribution>currentRect</dfn> attribute
-    to the smallest <a>Rectangle</a> containing the <a>visual
+    of |A| to the smallest <a>Rectangle</a> containing the <a>visual
     representation</a> of |N|.
 1. Return |A|.
 


### PR DESCRIPTION
Previous review thread: https://github.com/WICG/layout-instability/pull/32.

This version now incorporates a procedural algorithm to report the layout shift sources, and sets the node attribute to null when the shifted node is detached or inside shadow DOM (reusing the "get an element" algorithm from the Element Timing spec, as discussed).

The sources attribute is now a sequence instead of a FrozenArray.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 400 Bad Request :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 27, 2020, 5:43 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fskobes%2Flayout-instability%2Fedb9749c5089c853bc5a2496647bfdc3d4a753f2%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
Bikeshed has updated to Python 3, but you are trying to run it with
Python 2.7.9. For instructions on upgrading, please check:
https://tabatkins.github.io/bikeshed/#installing
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WICG/layout-instability%2336.)._
</details>
