### PR TITLE
Use FrozenArray instead of sequence.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -348,7 +348,7 @@ events are also not excluding inputs.
     readonly attribute double value;
     readonly attribute boolean hadRecentInput;
     readonly attribute DOMHighResTimeStamp lastInputTime;
-    readonly attribute sequence&lt;LayoutShiftAttribution&gt; sources;
+    readonly attribute FrozenArray&lt;LayoutShiftAttribution&gt; sources;
     [Default] object toJSON();
   };
 </pre>
@@ -471,7 +471,7 @@ When asked to <dfn>report the layout shift sources</dfn> for an active
             <a href="https://infra.spec.whatwg.org/#list-replace">replace</a>
             |smallest| with |N| in |C|.
 
-1. Return a <a>sequence</a> of {{LayoutShiftAttribution}} objects created
+1. Return a {{FrozenArray}} of {{LayoutShiftAttribution}} objects created
     by running the algorithm to <a>create the attribution</a> once
     for each member of |C|.
 


### PR DESCRIPTION
Fixes #40 .


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/skobes/layout-instability/pull/41.html" title="Last updated on Mar 27, 2020, 9:24 PM UTC (dad24b8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/41/3171ca5...skobes:dad24b8.html" title="Last updated on Mar 27, 2020, 9:24 PM UTC (dad24b8)">Diff</a>