### PR TITLE
Fix editor syntax

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4,9 +4,9 @@ Status: CG-Draft
 Shortname: layout-instability
 Group: WICG
 Level: 1
-Editor: Steve Kobes, Google, https://google.com, skobes@chromium.org
-        Nicolás Peña Moreno, Google, https://google.com, npm@chromium.org
-        Emily Hanley, Google, https://google.com, eyaich@chromium.org
+Editor: Steve Kobes, Google https://google.com, skobes@chromium.org
+        Nicolás Peña Moreno, Google https://google.com, npm@chromium.org
+        Emily Hanley, Google https://google.com, eyaich@chromium.org
 URL: https://wicg.github.io/layout-instability
 Repository: https://github.com/WICG/layout-instability
 Abstract: This document defines an API that provides web page authors with insights into the stability of their pages based on movements of the elements on the page.


### PR DESCRIPTION
No comma between company and URL of the company.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/pull/43.html" title="Last updated on May 12, 2020, 8:50 PM UTC (de77a88)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/43/99c3887...de77a88.html" title="Last updated on May 12, 2020, 8:50 PM UTC (de77a88)">Diff</a>