### PR TITLE
s/or/and/ in "greater of X or Y" expressions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -268,7 +268,7 @@ Layout Shift Value {#sec-layout-shift-value}
 --------------------------------------------
 
 The <dfn export>viewport base distance</dfn> is the greater of the <a>visual
-viewport width</a> or the <a>visual viewport height</a>.
+viewport width</a> and the <a>visual viewport height</a>.
 
 The <dfn export>move vector</dfn> of a {{Node}} |N| is the two-dimensional
 offset in <a>pixel units</a> from
@@ -281,7 +281,7 @@ offset in <a>pixel units</a> from
 The <dfn export>move distance</dfn> of a {{Node}} |N| is the greater of
 
 * the absolute value of the horizontal component of the <a>move vector</a> of
-    |N|, or
+    |N|, and
 * the absolute value of the vertical component of the <a>move vector</a> of |N|.
 
 The <dfn export>maximum move distance</dfn> of a {{Document}} |D| is the
@@ -291,7 +291,7 @@ greatest <a>move distance</a> of any {{Node}} in the <a>unstable node set</a> of
 The <dfn export>distance fraction</dfn> of a {{Document}} |D| is the lesser of
 
 * the <a>maximum move distance</a> of |D| divided by the <a>viewport base
-    distance</a>, or
+    distance</a>, and
 * 1.0.
 
 The <dfn export>node impact region</dfn> of an <a>unstable</a> {{Node}} |N|


### PR DESCRIPTION
(apologies for the pedantry)

The spec has a few instances of "...the greater of X or Y"

Strictly speaking, that should say "and", not "or", I think.

Mathematically speaking:
* "X **and** Y" represents a set of two values which we can perform a "give-me-the-greatest-value" operation on.
*...whereas "X **or** Y" represents a single (indeterminate) value, and it doesn't really make sense to perform a give-me-the-greatest-value operation on that single indeterminate value.

Also, consistency-wise (and as a sanity-check on my instinct here): CSS specs do seem to say "the greatest of X **and** Y" (rather than "or"), when they use this sort of phrasing.

 e.g.:
> the greater of the number determined by the table-column elements **and** the number determined by the first row,

https://www.w3.org/TR/2011/PR-CSS2-20110412/tables.html

> the greater of the resolved min-width, CAPMIN, and GRIDMIN.

https://www.w3.org/TR/css-tables-3/

> the greater of the two applicable Membership fees (for "A" and "B"). 

https://www.w3.org/Consortium/membership-faq


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dholbert/layout-instability/pull/54.html" title="Last updated on Jun 28, 2020, 8:16 PM UTC (68312a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/54/2f60ce1...dholbert:68312a0.html" title="Last updated on Jun 28, 2020, 8:16 PM UTC (68312a0)">Diff</a>