### PR TITLE
s/MUST/must/

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -356,7 +356,7 @@ events are also not excluding inputs.
 All attributes have the values which are assigned to them by the steps to
 <a>report the layout shift</a>.
 
-A user agent implementing the Layout Instability API MUST include
+A user agent implementing the Layout Instability API must include
 <code>"layout-shift"</code> in {{PerformanceObserver/supportedEntryTypes}} for
 <a href="https://html.spec.whatwg.org/multipage/window-object.html#the-window-object">Window</a>
 contexts. This allows developers to detect support for the Layout Instability API.


### PR DESCRIPTION
The footer boilerplate in this spec says:
> The key words “MUST”,  [etc] in the normative parts of this document are to be interpreted as described in RFC 2119. However, for readability, these words **do not appear in all uppercase letters in this specification.**

Yet, there is currently an instance of "MUST" (all uppercase) in this specification.

This commit fixes that.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dholbert/layout-instability/pull/56.html" title="Last updated on Jun 28, 2020, 10:23 PM UTC (a51f9e2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/56/2f60ce1...dholbert:a51f9e2.html" title="Last updated on Jun 28, 2020, 10:23 PM UTC (a51f9e2)">Diff</a>