### PR TITLE
Fix specification of transform-change exclusion.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -215,15 +215,14 @@ is defined as follows:
     starting point of |N| in |C| is the two-dimensional offset in <a>pixel
     units</a> from the origin of |C| to the <a>flow-relative</a> starting corner
     of the first <a>fragment</a> of the <a>principal box</a> of |N|, calculated
-    as if every <a>transformed element</a> in the <a>node document</a> of |N|
-    had a <a>transformation matrix</a> equal to the identity matrix.
+    as if every <a>transformed element</a> had a <a>transformation matrix</a>
+    equal to the identity matrix.
 
 * If |N| is a <a>text node</a>, the starting point of |N| in |C| is the
     two-dimensional offset in <a>pixel units</a> from the origin of C to the
     <a>flow-relative</a> starting corner of the first <a>line box</a> generated
-    by |N|, calculated as if every <a>transformed element</a> in the
-    <a>node document</a> of |N| had a <a>transformation matrix</a> equal
-    to the identity matrix.
+    by |N|, calculated as if every <a>transformed element</a> had a
+    <a>transformation matrix</a> equal to the identity matrix.
 
 NOTE: The CSS transform is ignored for the calculation of the starting point,
 to ensure that a node is not made unstable by a transform change. However, the CSS

--- a/index.bs
+++ b/index.bs
@@ -70,7 +70,6 @@ urlPrefix: https://wicg.github.io/element-timing/; spec: ELEMENT-TIMING;
     type: dfn; url: #get-an-element; text: get an element;
 </pre>
 <pre class=link-defaults>
-spec:css-transforms-1; type:dfn; text:local coordinate system
 spec:css-break-4; type:dfn; text:fragment
 </pre>
 
@@ -215,12 +214,21 @@ is defined as follows:
 * If |N| is an {{Element}} which generates one or more <a>boxes</a>, the
     starting point of |N| in |C| is the two-dimensional offset in <a>pixel
     units</a> from the origin of |C| to the <a>flow-relative</a> starting corner
-    of the first <a>fragment</a> of the <a>principal box</a> of |N|.
+    of the first <a>fragment</a> of the <a>principal box</a> of |N|, calculated
+    as if every <a>transformed element</a> in the <a>node document</a> of |N|
+    had a <a>transformation matrix</a> equal to the identity matrix.
 
 * If |N| is a <a>text node</a>, the starting point of |N| in |C| is the
     two-dimensional offset in <a>pixel units</a> from the origin of C to the
     <a>flow-relative</a> starting corner of the first <a>line box</a> generated
-    by |N|.
+    by |N|, calculated as if every <a>transformed element</a> in the
+    <a>node document</a> of |N| had a <a>transformation matrix</a> equal
+    to the identity matrix.
+
+NOTE: The CSS transform is ignored for the calculation of the starting point,
+to ensure that a node is not made unstable by a transform change. However, the CSS
+transform is not ignored for the calculation of the visual representation and
+the associated exclusion of points outside of the viewport.
 
 The <dfn export>visual representation</dfn> of a {{Node}} |N| is defined as
 follows:
@@ -269,11 +277,14 @@ A {{Node}} |N| is <dfn export>unstable</dfn> if:
 * there does not exist an {{Element}} |P| such that
     1. currently and <a>in the previous frame</a>, |P| is in the <a>containing
         block chain</a> of |N|, and
-    1. currently and <a>in the previous frame</a>, |P| has a <a>local coordinate
-        system</a> or a <a>scrollable overflow region</a>, and
+    1. currently and <a>in the previous frame</a>, |P| has a <a>scrollable
+        overflow region</a>, and
     1. |P| is not <a>unstable</a>, and
-    1. |N| <a>has not shifted</a> in the coordinate space of the <a>local
-        coordinate system</a> or <a>scrollable overflow region</a> of |P|.
+    1. |N| <a>has not shifted</a> in the coordinate space of the <a>scrollable
+        overflow region</a> of |P|.
+
+NOTE: The final condition is intended to prevent nodes from being considered
+unstable solely because of a scroll operation.
 
 The <dfn export>unstable node set</dfn> of a {{Document}} |D| is the set
 containing every <a>unstable</a> <a>shadow-including descendant</a> of |D|.


### PR DESCRIPTION
Adopts the suggestion of http://crbug.com/1109053#c6 where wangxianzhu correctly notes:

it seems unnecessary to mention "local coordinate system" at all. We can just calculate the starting point from the viewport or scroll parent as if the transforms don't exist"

Fixes #59


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/skobes/layout-instability/pull/72.html" title="Last updated on Sep 12, 2020, 1:31 AM UTC (fd00b57)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/72/0ba1256...skobes:fd00b57.html" title="Last updated on Sep 12, 2020, 1:31 AM UTC (fd00b57)">Diff</a>