### PR TITLE
Clamp move vector to 2x viewport.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -293,7 +293,11 @@ offset in <a>pixel units</a> from
 * the <a>previous frame starting point</a> of |N| in the coordinate space of the
     <a>viewport</a>, to
 * the <a>starting point</a> of |N| in the coordinate space of the
-    <a>viewport</a>.
+    <a>viewport</a>,
+
+but reduced as necessary to ensure that its horizontal component is not greater
+than twice the <a>visual viewport width</a> and its vertical component is not
+greater than twice the <a>visual viewport height</a>.
 
 The <dfn export>move distance</dfn> of a {{Node}} |N| is the greater of
 


### PR DESCRIPTION
Fixes #62 

This is simpler than my previous proposal of viewport height + element height, and probably better in the case of pathologically large elements.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/skobes/layout-instability/pull/73.html" title="Last updated on Sep 10, 2020, 5:10 PM UTC (38b86a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/73/0ba1256...skobes:38b86a6.html" title="Last updated on Sep 10, 2020, 5:10 PM UTC (38b86a6)">Diff</a>