### PR TITLE
Revert "Clamp move vector to 2x viewport."

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -305,11 +305,7 @@ offset in <a>pixel units</a> from
 * the <a>previous frame starting point</a> of |N| in the coordinate space of the
     <a>viewport</a>, to
 * the <a>starting point</a> of |N| in the coordinate space of the
-    <a>viewport</a>,
-
-but reduced as necessary to ensure that its horizontal component is not greater
-than twice the <a>visual viewport width</a> and its vertical component is not
-greater than twice the <a>visual viewport height</a>.
+    <a>viewport</a>.
 
 The <dfn export>move distance</dfn> of a {{Node}} |N| is the greater of
 


### PR DESCRIPTION
This change had no effect, because the distance fraction had its own
(stricter) clamp.

This reverts commit 38b86a6bf86564062753bfb32b09f43e6111396b.

Fixes #62


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/skobes/layout-instability/pull/74.html" title="Last updated on Sep 15, 2020, 2:53 PM UTC (eb51c25)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/74/33f53de...skobes:eb51c25.html" title="Last updated on Sep 15, 2020, 2:53 PM UTC (eb51c25)">Diff</a>