### PR TITLE
Regenerate spec

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -543,8 +543,12 @@ run the following steps:
 Security & privacy considerations {#priv-sec}
 ===============================================
 
-Layout instability bears an indirect relationship to <a href="https://w3c.github.io/resource-timing/">resource timing</a>, as slow resources could cause intermediate layouts that would not otherwise be performed.
-Resource timing information can be used by malicious websites for <a>statistical fingerprinting</a>.
-The layout instability API only reports instability in the current browsing context.
-It does not directly provide any aggregation of instability scores across multiple browsing contexts.
-Developers can implement such aggregation manually, but browsing contexts with different <a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin">origins</a> would need to cooperate to share instability scores.
+Layout instability bears an indirect relationship to
+<a href="https://w3c.github.io/resource-timing/">resource timing</a>, as slow resources could cause
+intermediate layouts that would not otherwise be performed. Resource timing information can be used
+by malicious websites for <a>statistical fingerprinting</a>. The layout instability API only reports
+instability in the current browsing context. It does not directly provide any aggregation of
+instability scores across multiple browsing contexts. Developers can implement such aggregation
+manually, but browsing contexts with different
+<a href="https://html.spec.whatwg.org/multipage/origin.html#concept-origin">origins</a> would need
+to cooperate to share instability scores.


### PR DESCRIPTION
Wrap security-privacy paragraph to 100, to regenerate the spec in latest bikeshed. Fixes https://github.com/WICG/layout-instability/issues/76


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/pull/79.html" title="Last updated on Sep 29, 2020, 2:18 PM UTC (20e21c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/79/3c3132d...20e21c7.html" title="Last updated on Sep 29, 2020, 2:18 PM UTC (20e21c7)">Diff</a>