### PR TITLE
Pass global object to current high res time

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -465,7 +465,7 @@ When asked to <dfn export>report the layout shift</dfn> for an active
     1. Set |newEntry|'s {{PerformanceEntry/entryType}} attribute to
         <code>"layout-shift"</code>.
     1. Set |newEntry|'s {{PerformanceEntry/startTime}} attribute to <a>current
-        high resolution time</a>.
+        high resolution time</a> given |D|'s <a>relevant global object</a>.
     1. Set |newEntry|'s {{PerformanceEntry/duration}} attribute to 0.
     1. Set |newEntry|'s <dfn attribute for=LayoutShift>value</dfn> attribute to
         the current <a>layout shift value</a> of |D|.


### PR DESCRIPTION
Fixes https://github.com/WICG/layout-instability/issues/78


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/pull/82.html" title="Last updated on Oct 6, 2020, 4:56 PM UTC (619f79c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/82/d939e7b...619f79c.html" title="Last updated on Oct 6, 2020, 4:56 PM UTC (619f79c)">Diff</a>