### PR TITLE
Fix computed value computation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -291,7 +291,7 @@ A {{Node}} |N| is <dfn export>unstable</dfn> if:
     * an {{Element}} which generates one or more <a>boxes</a>, or
     * a <a>text node</a>; and
 * currently and <a>in the previous frame</a>, the <a>computed value</a> of the <a>visibility</a>
-    property for |N| and for every ancestor of |N| equals "visible"; and
+    property for |N| equals "visible"; and
 * currently and <a>in the previous frame</a>, the <a>computed value</a> of the <a>opacity</a>
     property for |N| and for every ancestor of |N| is not equal to 0; and
 * |N| <a>has shifted</a> in the coordinate space of the <a>viewport</a>; and

--- a/index.bs
+++ b/index.bs
@@ -290,8 +290,10 @@ A {{Node}} |N| is <dfn export>unstable</dfn> if:
 * |N| is either
     * an {{Element}} which generates one or more <a>boxes</a>, or
     * a <a>text node</a>; and
-* currently and <a>in the previous frame</a>, the <a>computed value</a> of the <a>visibility</a> property for |N| equals "visible"; and
-* currently and <a>in the previous frame</a>, the <a>computed value</a> of the <a>opacity</a> property for |N| is not equal to 0; and
+* currently and <a>in the previous frame</a>, the <a>computed value</a> of the <a>visibility</a>
+    property for |N| and for every ancestor of |N| equals "visible"; and
+* currently and <a>in the previous frame</a>, the <a>computed value</a> of the <a>opacity</a>
+    property for |N| and for every ancestor of |N| is not equal to 0; and
 * |N| <a>has shifted</a> in the coordinate space of the <a>viewport</a>; and
 * |N| <a>has shifted</a> in the coordinate space of the <a>initial containing
     block</a>; and


### PR DESCRIPTION
When determining whether the node can be considered unstable, we need to consider not just the node but also its ancestors, since computed value does not account for inheritance. Fixes https://github.com/WICG/layout-instability/issues/61


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/pull/96.html" title="Last updated on Feb 24, 2021, 6:12 PM UTC (f9816d3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/96/f831584...f9816d3.html" title="Last updated on Feb 24, 2021, 6:12 PM UTC (f9816d3)">Diff</a>