### PR TITLE
Ignore inline clip crossers.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -287,8 +287,7 @@ A {{Node}} |N| <dfn export>has shifted</dfn> in a coordinate space |C| if:
 
 Otherwise, |N| <dfn export>has not shifted</dfn> in |C|.
 
-A {{Node}} |N| is <dfn export>unstable</dfn> if:
-
+A {{Node}} |N| is an <dfn export>unstable-candidate</dfn> if:
 * |N| is either
     * an {{Element}} which generates one or more <a>boxes</a>, or
     * a <a>text node</a>; and
@@ -304,12 +303,30 @@ A {{Node}} |N| is <dfn export>unstable</dfn> if:
         block chain</a> of |N|, and
     1. currently and <a>in the previous frame</a>, |P| has a <a>scrollable
         overflow region</a>, and
-    1. |P| is not <a>unstable</a>, and
+    1. |P| is not an <a>unstable-candidate</a>, and
     1. |N| <a>has not shifted</a> in the coordinate space of the <a>scrollable
         overflow region</a> of |P|.
 
-NOTE: The final condition is intended to prevent nodes from being considered
-unstable solely because of a scroll operation.
+NOTE: The condition relating to a scrollable overflow region is intended to prevent
+nodes from being considered unstable solely because of a scroll operation.
+
+A {{Node}} |N| is <dfn export>unstable</dfn> if it is an <a>unstable-candidate</a>
+and it is not an <a>inline clip crosser</a>.
+
+A {{Node}} |N| is an <dfn export>inline clip crosser</dfn> if:
+* |N| is an <a>unstable-candidate</a>;
+* either the <a>visual representation</a> or the <a>previous frame visual representation</a>
+    of |N| is empty; and
+* |N| would not be an <a>unstable-candidate</a> if the phrase "either the horizontal or
+    vertical direction" in the definition of <a>differs significantly</a> were replaced
+    by "the vertical direction" (if the <a>block axis</a> of |N| is vertical)
+    or "the horizontal direction" (if the <a>block axis</a> of |N| is horizontal).
+
+NOTE: An example of an inline clip crosser is an element that shifts into or
+out of view by moving in the inline direction across the boundary of a containing
+clip. We exclude such an element from the unstable node set as long as it don't
+shift in the block flow direction. This can make it easier to build certain types
+of "carousel" user interface controls.
 
 The <dfn export>unstable node set</dfn> of a {{Document}} |D| is the set
 containing every <a>unstable</a> <a>shadow-including descendant</a> of |D|.


### PR DESCRIPTION
Fixes #98


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/skobes/layout-instability/pull/101.html" title="Last updated on Apr 6, 2021, 11:28 PM UTC (1260fbb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/101/0043ac9...skobes:1260fbb.html" title="Last updated on Apr 6, 2021, 11:28 PM UTC (1260fbb)">Diff</a>