### PR TITLE
Replace fling by the commonly known flick

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -405,12 +405,12 @@ Excluding inputs generally include
 <a href="https://www.w3.org/TR/uievents/#keydown">keydown</a>,
 <a href="https://www.w3.org/TR/pointerevents/#the-pointerdown-event">pointerdown</a>, and
 <a>change events</a>.
-However, an event whose only effect is to begin or update a fling or scroll
+However, an event whose only effect is to begin or update a flick or scroll
 gesture is not an excluding input.
 
 The user agent may delay the reporting of layout shifts after a
 <a href="https://www.w3.org/TR/pointerevents/#the-pointerdown-event">pointerdown</a> event
-until such time as it is known that the event does not begin a fling or scroll
+until such time as it is known that the event does not begin a flick or scroll
 gesture.
 
 The <a href="https://www.w3.org/TR/uievents/#event-type-mousemove">mousemove</a> and


### PR DESCRIPTION
As a non-native speaker, I had no idea what "fling" meant. It seems to be an Android specific term. 

Even in the Android community, it might not be that well understood: From [Advanced Android Application Development: Handling Advanced User Input](https://www.informit.com/articles/article.aspx?p=2262133&seqNum=3)
> onFling: Called after the user presses and then moves a finger in an accelerating motion before lifting it. This is commonly called a flick gesture and usually results in some motion continuing after the user lifts the finger.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rik/layout-instability/pull/102.html" title="Last updated on Apr 15, 2021, 10:59 PM UTC (c9371fd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/102/0b186d4...rik:c9371fd.html" title="Last updated on Apr 15, 2021, 10:59 PM UTC (c9371fd)">Diff</a>