### PR TITLE
Add note about recent input to DCLS and CLS dfns.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -124,12 +124,19 @@ API does not expose these values.)
 
 * The <dfn export>document cumulative layout shift (DCLS) score</dfn> is the
     sum of every <a>layout shift value</a> that is reported inside a single
-    <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>.
-    (The DCLS score does not account for layout instability inside descendant browsing contexts.)
+    <a for="/">browsing context</a>, ignoring those shifts occuring up to 500ms
+    after an <a>excluding input</a>. (The DCLS score does not account for
+    layout instability inside descendant browsing contexts, and deliberately
+    excludes instablity which is in response to user interaction.)
 
 * The <dfn export>cumulative layout shift (CLS) score</dfn> is the sum of every
-    <a>layout shift value</a> that is reported inside a <a>top-level browsing context</a>,
-    plus a fraction (the <a>subframe weighting factor</a>) of each <a>layout shift value</a> that is reported inside any <a href="https://html.spec.whatwg.org/multipage/browsers.html#list-of-the-descendant-browsing-contexts">descendant browsing context</a>.
+    <a>layout shift value</a> that is reported inside a <a>top-level browsing
+    context</a>, plus a fraction (the <a>subframe weighting factor</a>) of each
+    <a>layout shift value</a> that is reported inside any <a
+    href="https://html.spec.whatwg.org/multipage/browsers.html#list-of-the-descendant-browsing-contexts">descendant
+    browsing context</a>, ignoring all shifts occuring up to 500ms after an
+    <a>excluding input</a>. (The CLS score excludes instability which is in
+    response to user interaction.)
 
 * The <dfn export>subframe weighting factor</dfn> for a <a>layout shift value</a>
     in a <a>child browsing context</a> is the fraction of the top-level <a>viewport</a> that is occupied by the <a>viewport</a> of the child browsing context.


### PR DESCRIPTION
The non-normative definitions of DCLS and CLS did not include any
mention of the recent user input exclusion, even though it was used in
the sample calculation code.

Fixes: #113


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/clelland/layout-instability/pull/114.html" title="Last updated on Jan 25, 2022, 3:33 PM UTC (5a9cacc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/114/3675a56...clelland:5a9cacc.html" title="Last updated on Jan 25, 2022, 3:33 PM UTC (5a9cacc)">Diff</a>