### PR TITLE
Update docs to mention layout shift sources being sorted by impact area

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -151,7 +151,9 @@ Source attribution {#source-attribution}
 
 In addition to the layout shift value, the API reports a sampling of up to five
 DOM elements whose layout shifts most substantially contributed to the layout
-shift value for an animation frame.
+shift value for an animation frame. The <a href="#dom-layoutshift-sources">sources</a>
+are sorted by impact area in descending order, so the first element represents
+the element that contributed most to the layout shift.
 
 It is possible that the true "root cause" of instability will be only
 indirectly related to the DOM element that experiences a layout shift.
@@ -186,6 +188,12 @@ Usage example {#example}
           timestamp: entry.startTime
         });
         cumulativeLayoutShiftScore += entry.value;
+
+        // Sources are sorted by impact area in descending order.
+        // The first element contributed most to the layout shift.
+        if (entry.sources && entry.sources.length > 0) {
+          console.log('Largest contributing element:', entry.sources[0].node);
+        }
       }
     }
 
@@ -449,6 +457,11 @@ events are also not excluding inputs.
 All attributes have the values which are assigned to them by the steps to
 <a>report the layout shift</a>.
 
+The <dfn attribute for=LayoutShift>sources</dfn> attribute returns a
+{{FrozenArray}} of {{LayoutShiftAttribution}} objects, sorted in descending order
+by impact area. The first element has the largest <a>node impact region</a> and
+represents the element that contributed most to the layout shift.
+
 A user agent implementing the Layout Instability API must include
 <code>"layout-shift"</code> in {{PerformanceObserver/supportedEntryTypes}} for
 <a href="https://html.spec.whatwg.org/multipage/window-object.html#the-window-object">Window</a>
@@ -525,7 +538,7 @@ When asked to <dfn export>report the layout shift</dfn> for an active
     1. Set |newEntry|'s <dfn attribute for=LayoutShift>hadRecentInput</dfn>
         attribute to <code>true</code> if {{LayoutShift/lastInputTime}} is less
         than 500 milliseconds in the past, and <code>false</code> otherwise.
-    1. Set |newEntry|'s <dfn attribute for=LayoutShift>sources</dfn> attribute
+    1. Set |newEntry|'s {{LayoutShift/sources}} attribute
         to the result of invoking the algorithm to <a>report the layout shift
         sources</a> for |D|.
     1. <a href="https://w3c.github.io/performance-timeline/#dfn-queue-a-performanceentry">Queue the PerformanceEntry</a>
@@ -567,6 +580,15 @@ When asked to <dfn>report the layout shift sources</dfn> for an active
             of |smallest|, then
             <a href="https://infra.spec.whatwg.org/#list-replace">replace</a>
             |smallest| with |N| in |C|.
+
+1. <a href="https://infra.spec.whatwg.org/#list-sort-in-descending-order">Sort</a>
+    |C| in descending order, with |a| being less than |b| if the area
+    of the <a>node impact region</a> of |a| is less than the area
+    of the <a>node impact region</a> of |b|.
+
+    NOTE: This ensures that the <a href="#dom-layoutshift-sources">sources</a>
+    attribute exposes layout shift sources in descending order by impact area,
+    with the element that contributed most to the layout shift appearing first.
 
 1. Return a {{FrozenArray}} of {{LayoutShiftAttribution}} objects created
     by running the algorithm to <a>create the attribution</a> once

--- a/index.bs
+++ b/index.bs
@@ -75,6 +75,14 @@ urlPrefix: https://www.w3.org/TR/css-color-3; spec: CSS-COLOR-3;
     type: dfn; url: #transparency; text: opacity;
 urlPrefix: https://html.spec.whatwg.org/multipage;
     type: dfn; url: #event-change; text: change event;
+urlPrefix: https://html.spec.whatwg.org/multipage/browsers.html; spec: HTML;
+    type: dfn; url: #browsing-context; text: browsing context;
+    type: dfn; url: #top-level-browsing-context; text: top-level browsing context;
+    type: dfn; url: #child-browsing-context; text: child browsing context;
+    type: dfn; url: #list-of-the-descendant-browsing-contexts; text: descendant browsing context;
+urlPrefix: https://html.spec.whatwg.org/multipage/webappapis.html; spec: HTML;
+    type: dfn; url: #event-loop-processing-model; text: event loop processing model;
+    type: dfn; url: #update-the-rendering; text: update the rendering;
 </pre>
 <pre class=link-defaults>
 spec:css-break-4; type:dfn; text:fragment
@@ -124,12 +132,12 @@ API does not expose these values.)
 
 * The <dfn export>document cumulative layout shift (DCLS) score</dfn> is the
     sum of every <a>layout shift value</a> that is reported inside a single
-    <a href="https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing context</a>.
+    <a>browsing context</a>.
     (The DCLS score does not account for layout instability inside descendant browsing contexts.)
 
 * The <dfn export>cumulative layout shift (CLS) score</dfn> is the sum of every
     <a>layout shift value</a> that is reported inside a <a>top-level browsing context</a>,
-    plus a fraction (the <a>subframe weighting factor</a>) of each <a>layout shift value</a> that is reported inside any <a href="https://html.spec.whatwg.org/multipage/browsers.html#list-of-the-descendant-browsing-contexts">descendant browsing context</a>.
+    plus a fraction (the <a>subframe weighting factor</a>) of each <a>layout shift value</a> that is reported inside any <a>descendant browsing context</a>.
 
 * The <dfn export>subframe weighting factor</dfn> for a <a>layout shift value</a>
     in a <a>child browsing context</a> is the fraction of the top-level <a>viewport</a> that is occupied by the <a>viewport</a> of the child browsing context.


### PR DESCRIPTION
## Summary
Define the ordering of `LayoutShift.sources` to be sorted by impact area in descending order.
This ensures that the element which contributed most to the layout shift appears first in the array.

 ## Motivation
 This change aligns the specification with:
  - The Chromium implementation (see https://chromium-review.googlesource.com/c/chromium/src/+/7196706)
  - The updated MDN documentation (see https://github.com/mdn/content/pull/42145)
  - Issue: https://issues.chromium.org/issues/450950606

Without this clarification, developers cannot rely on any consistent ordering of the `sources` array, making it harder to programmatically identify the most impactful elements causing layout shifts.

## Changes
This PR adds explicit documentation and normative algorithm steps to specify that layout shift sources are sorted by impact area:
  1. Source Attribution section: Added non-normative explanation that `sources` are sorted by impact area in descending order
  2. Usage Example: Enhanced with comments demonstrating how to access the largest contributing element
  3. LayoutShift Interface: Added formal documentation for the sources attribute explaining the ordering guarantee
  4. Algorithm: Added normative sorting step in the "report the layout shift sources" algorithm to sort the list by node impact region area in descending order


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/anediaz/layout-instability/pull/126.html" title="Last updated on Dec 17, 2025, 12:10 PM UTC (82961c4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/layout-instability/126/3675a56...anediaz:82961c4.html" title="Last updated on Dec 17, 2025, 12:10 PM UTC (82961c4)">Diff</a>